### PR TITLE
upgrade httpotion dependency to 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExVCR.Mixfile do
       {:exactor, "~> 0.7"},
       {:exjsx, "~> 3.0"},
       {:ibrowse, github: "cmullaparthi/ibrowse", optional: true},
-      {:httpotion, "~> 0.2", optional: true},
+      {:httpotion, "~> 1.0", optional: true},
       {:httpoison, "~> 0.5"},
       {:excoveralls, "~> 0.3", only: :dev},
       {:http_server, github: "parroty/http_server", only: [:dev, :test]}

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "hackney": {:hex, :hackney, "0.14.3"},
   "http_server": {:git, "git://github.com/parroty/http_server.git", "fbc68ed552996e0d38863e8f9e59dfd64df43d88", []},
   "httpoison": {:hex, :httpoison, "0.5.0"},
-  "httpotion": {:hex, :httpotion, "0.2.4"},
+  "httpotion": {:hex, :httpotion, "1.0.0"},
   "ibrowse": {:git, "git://github.com/cmullaparthi/ibrowse.git", "fae777f86d31407c4442a37f8017f6f2ea6c0a22", []},
   "idna": {:hex, :idna, "1.0.1"},
   "jsex": {:hex, :jsex, "2.0.0"},


### PR DESCRIPTION
httpotion recently bumped their version to 1.0.0, I'm trying to use httpotion and exvcr in a library but the version requirements are clashing. Could we bump the httpotion dependency?

Thanks!
