### PR TITLE
Replace erlang.now with os.timestamp

### DIFF
--- a/lib/exvcr/util.ex
+++ b/lib/exvcr/util.ex
@@ -7,6 +7,6 @@ defmodule ExVCR.Util do
   Returns uniq_id string based on current timestamp (ex. 1407237617115869)
   """
   def uniq_id do
-    :erlang.now |> Tuple.to_list |> Enum.join("")
+    :os.timestamp |> Tuple.to_list |> Enum.join("")
   end
 end


### PR DESCRIPTION
:erlang.now is deprecated in Erlang 18, and so this change its use to
:os.timestamp instead.

Unfortunately I don't think os.timestamp has the same uniqueness guarantees that erlang.now had, and it is used to generate a uniq_id, and so may not be an appropriate solution.