### PR TITLE
Add support for POST requests with form-encoded data in the hackney adapter

### DIFF
--- a/lib/exvcr/adapter/hackney/converter.ex
+++ b/lib/exvcr/adapter/hackney/converter.ex
@@ -43,4 +43,10 @@ defmodule ExVCR.Adapter.Hackney.Converter do
       body: Atom.to_string(reason)
     }
   end
+
+  defp parse_request_body({:form, body}) do
+    :hackney_request.encode_form(body) |> elem(2) |> to_string |> ExVCR.Filter.filter_sensitive_data
+  end
+
+  defp parse_request_body(body), do: super(body)
 end

--- a/test/adapter_hackney_test.exs
+++ b/test/adapter_hackney_test.exs
@@ -56,6 +56,12 @@ defmodule ExVCR.Adapter.HackneyTest do
     end
   end
 
+  test "post with form-encoded data" do
+    use_cassette "httpoison_post_form" do
+      HTTPoison.post!("http://httpbin.org/post", {:form, [key: "value"]}, %{"Content-type" => "application/x-www-form-urlencoded"})
+    end
+  end
+
   test "put method" do
     use_cassette "httpoison_put" do
       assert_response HTTPoison.put!("http://httpbin.org/put", "test")


### PR DESCRIPTION
HTTPoison (and hackney) use a request body like `{:form, [key: "value"]}` for form data. ExVCR was choking on this by calling `to_string/1` on the body, so I've added another pattern-matched function definition to the hackney converter to handle this case.