### PR TITLE
[filter] Filter sensitive data in `request url`

### DIFF
--- a/lib/exvcr/filter.ex
+++ b/lib/exvcr/filter.ex
@@ -23,7 +23,7 @@ defmodule ExVCR.Filter do
       strip_query_params(url)
     else
       url
-    end
+    end |> filter_sensitive_data
   end
 
   @doc """
@@ -46,8 +46,8 @@ defmodule ExVCR.Filter do
   end
 
   defp is_header_allowed?(header_name) do
-    Enum.find(ExVCR.Setting.get(:response_headers_blacklist), fn(x) -> 
-      to_string(header_name) == x 
+    Enum.find(ExVCR.Setting.get(:response_headers_blacklist), fn(x) ->
+      to_string(header_name) == x
     end) == nil
   end
 end

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -62,10 +62,10 @@ defmodule ExVCR.Handler do
   end
 
   defp match_by_url(response, keys, recorder_options) do
-    if stub_mode?(recorder_options) do
-      request_url = response[:request].url
-      key_url     = to_string(keys[:url])
+    request_url = response[:request].url
+    key_url     = to_string(keys[:url]) |> ExVCR.Filter.filter_sensitive_data
 
+    if stub_mode?(recorder_options) do
       if match = Regex.run(~r/~r\/(.+)\//, request_url) do
         pattern = Regex.compile!(Enum.at(match, 1))
         Regex.match?(pattern, key_url)
@@ -73,8 +73,8 @@ defmodule ExVCR.Handler do
         request_url == key_url
       end
     else
-      request_url = parse_url(response[:request].url, recorder_options)
-      key_url     = parse_url(keys[:url], recorder_options)
+      request_url = parse_url(request_url, recorder_options)
+      key_url     = parse_url(key_url, recorder_options)
 
       request_url == key_url
     end


### PR DESCRIPTION
There are cases where the url may contain sensitive information, so I made a change to apply the filter also in the request url.

For example, in this case it is necessary to replace the project_id.
```js
[
  {
    "request": {
      // ...
      "url": "https://api.keen.io/3.0/projects/[project_id]/events/start"
    },
    // ...
  }
]
```