### PR TITLE
Match cassette requests on the request body

### DIFF
--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -14,6 +14,7 @@ defmodule ExVCR.Adapter.Hackney do
 
   defdelegate convert_from_string(string), to: ExVCR.Adapter.Hackney.Converter
   defdelegate convert_to_string(request, response), to: ExVCR.Adapter.Hackney.Converter
+  defdelegate parse_request_body(request_body), to: ExVCR.Adapter.Hackney.Converter
 
   @doc """
   Returns the name of the mock target module.
@@ -36,7 +37,9 @@ defmodule ExVCR.Adapter.Hackney do
   def generate_keys_for_request(request) do
     url    = Enum.fetch!(request, 1)
     method = Enum.fetch!(request, 0)
-    [url: url, method: method]
+    request_body = Enum.fetch(request, 3) |> parse_request_body
+
+    [url: url, method: method, request_body: request_body]
   end
 
   @doc """

--- a/lib/exvcr/adapter/hackney/converter.ex
+++ b/lib/exvcr/adapter/hackney/converter.ex
@@ -44,9 +44,9 @@ defmodule ExVCR.Adapter.Hackney.Converter do
     }
   end
 
-  defp parse_request_body({:form, body}) do
+  def parse_request_body({:form, body}) do
     :hackney_request.encode_form(body) |> elem(2) |> to_string |> ExVCR.Filter.filter_sensitive_data
   end
 
-  defp parse_request_body(body), do: super(body)
+  def parse_request_body(body), do: super(body)
 end

--- a/lib/exvcr/adapter/httpc.ex
+++ b/lib/exvcr/adapter/httpc.ex
@@ -11,6 +11,7 @@ defmodule ExVCR.Adapter.Httpc do
 
   defdelegate convert_from_string(string), to: ExVCR.Adapter.Httpc.Converter
   defdelegate convert_to_string(request, response), to: ExVCR.Adapter.Httpc.Converter
+  defdelegate parse_request_body(request_body), to: ExVCR.Adapter.Httpc.Converter
 
   @doc """
   Returns the name of the mock target module.
@@ -39,7 +40,9 @@ defmodule ExVCR.Adapter.Httpc do
     else
       url = Enum.fetch!(request, 1) |> elem(0)
       method = Enum.fetch!(request, 0)
-      [url: url, method: method]
+      request_body = Enum.fetch(request, 3) |> parse_request_body
+
+      [url: url, method: method, request_body: request_body]
     end
   end
 

--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -35,7 +35,11 @@ defmodule ExVCR.Adapter.IBrowse do
   def generate_keys_for_request(request) do
     url    = Enum.fetch!(request, 0)
     method = Enum.fetch!(request, 2)
-    [url: url, method: method]
+    request_body = case Enum.fetch(request, 3) do
+      {:ok, body} -> body
+      :error -> ""
+    end
+    [url: url, method: method, request_body: request_body]
   end
 
   @doc """

--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -11,6 +11,7 @@ defmodule ExVCR.Adapter.IBrowse do
 
   defdelegate convert_from_string(string), to: ExVCR.Adapter.IBrowse.Converter
   defdelegate convert_to_string(request, response), to: ExVCR.Adapter.IBrowse.Converter
+  defdelegate parse_request_body(request_body), to: ExVCR.Adapter.IBrowse.Converter
 
   @doc """
   Returns the name of the mock target module.
@@ -35,10 +36,8 @@ defmodule ExVCR.Adapter.IBrowse do
   def generate_keys_for_request(request) do
     url    = Enum.fetch!(request, 0)
     method = Enum.fetch!(request, 2)
-    request_body = case Enum.fetch(request, 3) do
-      {:ok, body} -> body
-      :error -> ""
-    end
+    request_body = Enum.fetch(request, 3) |> parse_request_body
+
     [url: url, method: method, request_body: request_body]
   end
 

--- a/lib/exvcr/converter.ex
+++ b/lib/exvcr/converter.ex
@@ -55,15 +55,21 @@ defmodule ExVCR.Converter do
       end
       defoverridable [parse_url: 1]
 
-      defp parse_request_body(body) do
-        to_string(body) |> ExVCR.Filter.filter_sensitive_data
-      end
-      defoverridable [parse_request_body: 1]
-
       defp parse_keyword_list(params) do
         Enum.map(params, fn({k,v}) -> {k,to_string(v)} end)
       end
       defoverridable [parse_keyword_list: 1]
+
+      def parse_request_body(:error), do: ""
+
+      def parse_request_body({:ok, body}) do
+        parse_request_body(body)
+      end
+
+      def parse_request_body(body) do
+        to_string(body) |> ExVCR.Filter.filter_sensitive_data
+      end
+      defoverridable [parse_request_body: 1]
     end
   end
 end

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -97,7 +97,8 @@ defmodule ExVCR.Handler do
   end
 
   defp match_by_request_body(response, params) do
-    response[:request].request_body == params[:request_body] |> to_string
+    (response[:request].body || response[:request].request_body) ==
+      params[:request_body] |> to_string
   end
 
   defp get_response_from_server(request, recorder) do

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -58,7 +58,7 @@ defmodule ExVCR.Handler do
   end
 
   defp match_response(response, keys, recorder_options) do
-    match_by_url(response, keys, recorder_options) and match_by_method(response, keys)
+    match_by_url(response, keys, recorder_options) and match_by_method(response, keys) and match_by_request_body(response, keys)
   end
 
   defp match_by_url(response, keys, recorder_options) do
@@ -94,6 +94,10 @@ defmodule ExVCR.Handler do
     else
       to_string(params[:method]) == head[:request].method
     end
+  end
+
+  defp match_by_request_body(response, params) do
+    response[:request].request_body == params[:request_body] |> to_string
   end
 
   defp get_response_from_server(request, recorder) do

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -92,14 +92,15 @@ defmodule ExVCR.Mock do
   Prepare stub record based on specified option parameters.
   """
   def prepare_stub_record(options, adapter) do
-    method      = (options[:method] || "get") |> to_string
-    url         = (options[:url] || "~r/.+/") |> to_string
-    body        = (options[:body] || "Hello World") |> to_string
+    method        = (options[:method] || "get") |> to_string
+    url           = (options[:url] || "~r/.+/") |> to_string
+    body          = (options[:body] || "Hello World") |> to_string
+    request_body  = (options[:request_body] || "") |> to_string
 
     headers     = options[:headers] || adapter.default_stub_params(:headers)
     status_code = options[:status_code] || adapter.default_stub_params(:status_code)
 
-    record = %{ "request"  => %{"method" => method, "url" => url},
+    record = %{ "request"  => %{"method" => method, "url" => url, "request_body" => request_body},
                 "response" => %{"body" => body, "headers"  => headers, "status_code" => status_code} }
 
     [adapter.convert_from_string(record)]

--- a/lib/exvcr/records.ex
+++ b/lib/exvcr/records.ex
@@ -3,7 +3,7 @@ defmodule ExVCR.Record do
 end
 
 defmodule ExVCR.Request do
-  defstruct url: nil, headers: [], method: nil, body: nil, options: []
+  defstruct url: nil, headers: [], method: nil, body: nil, options: [], request_body: ""
 end
 
 defmodule ExVCR.Response do

--- a/test/handler_stub_mode_test.exs
+++ b/test/handler_stub_mode_test.exs
@@ -26,7 +26,7 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
   end
 
   test "method name in atom works" do
-    use_cassette :stub, [url: 'http://localhost', method: :post] do
+    use_cassette :stub, [url: 'http://localhost', method: :post, request_body: 'param1=value1&param2=value2'] do
       {:ok, status_code, _headers, _body} = :ibrowse.send_req('http://localhost', [], :post, 'param1=value1&param2=value2')
       assert status_code == '200'
     end
@@ -37,6 +37,14 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
       {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost', [], :get)
       assert status_code == '200'
       assert to_string(body) =~ ~r/Hello World/
+    end
+  end
+
+  test "request_body mismatch should raise error" do
+    assert_raise ExVCR.InvalidRequestError, fn ->
+      use_cassette :stub, [url: 'http://localhost', method: :post, request_body: '{"one" => 1}'] do
+        {:ok, _status_code, _headers, _body} = :ibrowse.send_req('http://localhost', [], :post)
+      end
     end
   end
 

--- a/test/handler_stub_mode_test.exs
+++ b/test/handler_stub_mode_test.exs
@@ -19,7 +19,7 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
 
   test "specified options should match with return values" do
     use_cassette :stub, [url: 'http://localhost', body: 'NotFound', status_code: 404] do
-      {:ok, status_code, headers, body} = :ibrowse.send_req('http://localhost', [], :get)
+      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost', [], :get)
       assert status_code == '404'
       assert to_string(body) =~ ~r/NotFound/
     end
@@ -27,14 +27,14 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
 
   test "method name in atom works" do
     use_cassette :stub, [url: 'http://localhost', method: :post] do
-      {:ok, status_code, headers, body} = :ibrowse.send_req('http://localhost', [], :post, 'param1=value1&param2=value2')
+      {:ok, status_code, _headers, _body} = :ibrowse.send_req('http://localhost', [], :post, 'param1=value1&param2=value2')
       assert status_code == '200'
     end
   end
 
   test "url matches as regex" do
     use_cassette :stub, [url: "~r/.+/"] do
-      {:ok, status_code, headers, body} = :ibrowse.send_req('http://localhost', [], :get)
+      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost', [], :get)
       assert status_code == '200'
       assert to_string(body) =~ ~r/Hello World/
     end
@@ -43,7 +43,7 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
   test "url mismatch should raise error" do
     assert_raise ExVCR.InvalidRequestError, fn ->
       use_cassette :stub, [url: 'http://localhost'] do
-        {:ok, status_code, headers, body} = :ibrowse.send_req('http://www.example.com', [], :get)
+        {:ok, _status_code, _headers, _body} = :ibrowse.send_req('http://www.example.com', [], :get)
       end
     end
   end
@@ -51,7 +51,7 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
   test "method mismatch should raise error" do
     assert_raise ExVCR.InvalidRequestError, fn ->
       use_cassette :stub, [url: 'http://localhost', method: "post"] do
-        {:ok, status_code, headers, body} = :ibrowse.send_req('http://localhost', [], :get)
+        {:ok, _status_code, _headers, _body} = :ibrowse.send_req('http://localhost', [], :get)
       end
     end
   end


### PR DESCRIPTION
The cassettes were only matching on url and method for the request. In cases were a request body was required but not provided, the request would still be matched and tests would pass. This PR validates that the request_body matches the expectation. If the request body does not match an `InvalidRequestError` is raised.