### PR TITLE
Response sequence

### DIFF
--- a/fixture/custom_cassettes/httpoison_get_alternate.json
+++ b/fixture/custom_cassettes/httpoison_get_alternate.json
@@ -1,0 +1,20 @@
+[
+  {
+    "request": {
+      "url": "http://example.com"
+    },
+    "response": {
+      "body": "Example Domain 1",
+      "status_code": 200
+    }
+  },
+  {
+    "request": {
+      "url": "http://example.com"
+    },
+    "response": {
+      "body": "Example Domain 2",
+      "status_code": 200
+    }
+  }
+]

--- a/test/adapter_hackney_test.exs
+++ b/test/adapter_hackney_test.exs
@@ -42,6 +42,13 @@ defmodule ExVCR.Adapter.HackneyTest do
     end
   end
 
+  test "get request with alternate" do
+    use_cassette "httpoison_get_alternate", custom: true do
+      assert %HTTPoison.Response{body: "Example Domain 1", status_code: 200} = HTTPoison.get!("http://example.com")
+      assert %HTTPoison.Response{body: "Example Domain 2", status_code: 200} = HTTPoison.get!("http://example.com")
+    end
+  end
+
   test "get with error" do
     use_cassette "httpoison_get_error" do
       assert_raise HTTPoison.Error, fn ->


### PR DESCRIPTION
According to the [VCR docs](1) identical requests in a cassette should be replayed in sequence, this can be useful for writing tests for behaviour such as retrying after receiving a 500 response.

I don't think this is the best implementation, but it's a starting point for discussion (and allows me to start relying on this behaviour).

Also, I'm sure there must be a much nicer way to do `Enum.reverse(acc) ++ tail ++ [response]`, but I'm pretty much a complete beginner to writing Elixir.

[1]: https://relishapp.com/vcr/vcr/v/2-9-3/docs/request-matching/identical-requests-are-replayed-in-sequence