### PR TITLE
Fix wrong request arguments handling for httpc adapter

### DIFF
--- a/fixture/vcr_cassettes/example_httpc_request_4_additional_options.json
+++ b/fixture/vcr_cassettes/example_httpc_request_4_additional_options.json
@@ -2,11 +2,18 @@
   {
     "request": {
       "body": "",
-      "headers": [],
+      "headers": {
+        "Content-Type": "text/html"
+      },
       "method": "get",
       "options": {
-        "httpc_options": [],
-        "http_options": []
+        "httpc_options": {
+          "body_format": "binary"
+        },
+        "http_options": {
+          "connect_timeout": "3000",
+          "timeout": "5000"
+        }
       },
       "request_body": "",
       "url": "http://example.com"

--- a/lib/exvcr/adapter/httpc.ex
+++ b/lib/exvcr/adapter/httpc.ex
@@ -35,14 +35,13 @@ defmodule ExVCR.Adapter.Httpc do
   Generate key for searching response.
   """
   def generate_keys_for_request(request) do
-    if Enum.count(request) <= 2 do
-      [url: Enum.fetch!(request, 0), method: :get]
-    else
-      url = Enum.fetch!(request, 1) |> elem(0)
-      method = Enum.fetch!(request, 0)
-      request_body = Enum.fetch(request, 3) |> parse_request_body
-
-      [url: url, method: method, request_body: request_body]
+    case request do
+      [method, {url, _} | _] ->
+        [url: url, method: method, request_body: nil]
+      [method, {url, _, _, body} | _] ->
+        [url: url, method: method, request_body: body]
+      [url | _] ->
+        [url: url, method: :get, request_body: nil]
     end
   end
 

--- a/test/adapter_httpc_test.exs
+++ b/test/adapter_httpc_test.exs
@@ -25,6 +25,17 @@ defmodule ExVCR.Adapter.HttpcTest do
     end
   end
 
+  test "example httpc request/4 with additional options" do
+    use_cassette "example_httpc_request_4_additional_options" do
+      {:ok, {{_, 200, _reason_phrase}, _headers, body}} = :httpc.request(
+        :get,
+        {'http://example.com', [{'Content-Type', 'text/html'}]},
+        [connect_timeout: 3000, timeout: 5000],
+        body_format: :binary)
+      assert to_string(body) =~ ~r/Example Domain/
+    end
+  end
+
   test "example httpc request error" do
     use_cassette "example_httpc_request_error" do
       {:error, {reason, _detail}} = :httpc.request('http://invalidurl')


### PR DESCRIPTION
The body was extracted from the wrong place in `generate_keys_for_request`. By the way, I've cleaned the function up a bit.