### PR TITLE
Make default match requests configurable

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,5 +7,6 @@ config :exvcr, [
     [pattern: "<PASSWORD>.+</PASSWORD>", placeholder: "PASSWORD_PLACEHOLDER"]
   ],
   filter_url_params: false,
-  response_headers_blacklist: []
+  response_headers_blacklist: [],
+  match_requests_on: [],
 ]

--- a/fixture/vcr_cassettes/same_query_params_on.json
+++ b/fixture/vcr_cassettes/same_query_params_on.json
@@ -1,0 +1,23 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34006/server?p=3"
+    },
+    "response": {
+      "body": "test_response_before",
+      "headers": {
+        "connection": "keep-alive",
+        "server": "Cowboy",
+        "date": "Sat, 19 Mar 2016 20:31:04 GMT",
+        "content-length": "20"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/same_request_body_params_on.json
+++ b/fixture/vcr_cassettes/same_request_body_params_on.json
@@ -1,0 +1,23 @@
+[
+  {
+    "request": {
+      "body": "p=3",
+      "headers": [],
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34006/server"
+    },
+    "response": {
+      "body": "test_response_before",
+      "headers": {
+        "connection": "keep-alive",
+        "server": "Cowboy",
+        "date": "Sat, 19 Mar 2016 20:29:34 GMT",
+        "content-length": "20"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/exvcr/config.ex
+++ b/lib/exvcr/config.ex
@@ -48,4 +48,11 @@ defmodule ExVCR.Config do
     blacklist = Enum.map(headers_blacklist, fn(x) -> String.downcase(x) end)
     Setting.set(:response_headers_blacklist, blacklist)
   end
+
+  @doc """
+  Sets default match_requests_on option
+  """
+  def match_requests_on(match_requests_on) do
+    Setting.set(:match_requests_on, match_requests_on)
+  end
 end

--- a/lib/exvcr/config_loader.ex
+++ b/lib/exvcr/config_loader.ex
@@ -36,5 +36,11 @@ defmodule ExVCR.ConfigLoader do
     else
       Config.response_headers_blacklist([])
     end
+
+    if env[:match_requests_on] != nil do
+      Config.match_requests_on(env[:match_requests_on])
+    else
+      Config.match_requests_on(Setting.get_default_match_requests_on)
+    end
   end
 end

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -74,7 +74,7 @@ defmodule ExVCR.Mock do
   """
   defmacro use_cassette(fixture, test) do
     quote do
-      use_cassette(unquote(fixture), [], unquote(test))
+      use_cassette(unquote(fixture), ExVCR.Setting.get(:match_requests_on), unquote(test))
     end
   end
 

--- a/lib/exvcr/setting.ex
+++ b/lib/exvcr/setting.ex
@@ -6,6 +6,7 @@ defmodule ExVCR.Setting do
   @ets_table :exvcr_setting
   @default_vcr_path    "fixture/vcr_cassettes"
   @default_custom_path "fixture/custom_cassettes"
+  @default_match_requests_on []
 
   def get(key) do
     setup
@@ -23,6 +24,7 @@ defmodule ExVCR.Setting do
 
   def get_default_vcr_path, do: @default_vcr_path
   def get_default_custom_path, do: @default_custom_path
+  def get_default_match_requests_on, do: @default_match_requests_on
 
   defp setup do
     if :ets.info(@ets_table) == :undefined do

--- a/test/config_loader_test.exs
+++ b/test/config_loader_test.exs
@@ -23,6 +23,7 @@ defmodule ExVCR.ConfigLoaderTest do
     ExVCR.Config.filter_sensitive_data("test_before1", "test_after1")
     ExVCR.Config.filter_url_params(true)
     ExVCR.Config.response_headers_blacklist(["Content-Type", "Accept"])
+    ExVCR.Config.match_requests_on([:query, :request_body])
 
     # Load default values (defined in config/config.exs)
     ExVCR.ConfigLoader.load_defaults
@@ -32,6 +33,7 @@ defmodule ExVCR.ConfigLoaderTest do
     assert ExVCR.Setting.get(:custom_library_dir) == "fixture/custom_cassettes"
     assert ExVCR.Setting.get(:filter_url_params) == false
     assert ExVCR.Setting.get(:response_headers_blacklist) == []
+    assert ExVCR.Setting.get(:match_requests_on) == []
   end
 
   test "loading default setting from empty values" do
@@ -40,12 +42,14 @@ defmodule ExVCR.ConfigLoaderTest do
     custom_cassette_library_dir = Application.get_env(:exvcr, :custom_cassette_library_dir)
     filter_sensitive_data       = Application.get_env(:exvcr, :filter_sensitive_data)
     response_headers_blacklist  = Application.get_env(:exvcr, :response_headers_blacklist)
+    match_requests_on           = Application.get_env(:exvcr, :match_requests_on)
 
     # Remove env values
     Application.delete_env(:exvcr, :vcr_cassette_library_dir)
     Application.delete_env(:exvcr, :custom_cassette_library_dir)
     Application.delete_env(:exvcr, :filter_sensitive_data)
     Application.delete_env(:exvcr, :response_headers_blacklist)
+    Application.delete_env(:exvcr, :match_requests_on)
 
     # Load default values
     ExVCR.ConfigLoader.load_defaults
@@ -55,11 +59,13 @@ defmodule ExVCR.ConfigLoaderTest do
     assert ExVCR.Setting.get(:custom_library_dir) == "fixture/custom_cassettes"
     assert ExVCR.Setting.get(:filter_url_params) == false
     assert ExVCR.Setting.get(:response_headers_blacklist) == []
+    assert ExVCR.Setting.get(:match_requests_on) == []
 
     # Restore env values
     Application.put_env(:exvcr, :vcr_cassette_library_dir, vcr_cassette_library_dir)
     Application.put_env(:exvcr, :custom_cassette_library_dir, custom_cassette_library_dir)
     Application.get_env(:exvcr, :filter_sensitive_data, filter_sensitive_data)
     Application.get_env(:exvcr, :response_headers_blacklist, response_headers_blacklist)
+    Application.get_env(:exvcr, :match_requests_on, match_requests_on)
   end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -52,4 +52,12 @@ defmodule ExVCR.ConfigTest do
     ExVCR.Config.response_headers_blacklist([])
     assert ExVCR.Setting.get(:response_headers_blacklist) == []
   end
+
+  test "add default match_requests_on" do
+    ExVCR.Config.match_requests_on([])
+    assert ExVCR.Setting.get(:match_requests_on) == []
+
+    ExVCR.Config.match_requests_on([:query, :request_body])
+    assert ExVCR.Setting.get(:match_requests_on) == [:query, :request_body]
+  end
 end

--- a/test/setting_test.exs
+++ b/test/setting_test.exs
@@ -27,4 +27,9 @@ defmodule ExVCR.SettingTest do
     ExVCR.Setting.set(:response_headers_blacklist, ["Content-Type", "Accept"])
     assert ExVCR.Setting.get(:response_headers_blacklist) == ["Content-Type", "Accept"]
   end
+
+  test "set match_requests_on" do
+    ExVCR.Setting.set(:match_requests_on, [:query, :request_body])
+    assert ExVCR.Setting.get(:match_requests_on) == [:query, :request_body]
+  end
 end


### PR DESCRIPTION
This keeps existing behavior of default match_requests_on to be `[]`