### PR TITLE
Support cassette_defaults from config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,5 +7,6 @@ config :exvcr, [
     [pattern: "<PASSWORD>.+</PASSWORD>", placeholder: "PASSWORD_PLACEHOLDER"]
   ],
   filter_url_params: false,
-  response_headers_blacklist: []
+  response_headers_blacklist: [],
+  cassette_defaults: [],
 ]

--- a/lib/exvcr/config.ex
+++ b/lib/exvcr/config.ex
@@ -48,4 +48,11 @@ defmodule ExVCR.Config do
     blacklist = Enum.map(headers_blacklist, fn(x) -> String.downcase(x) end)
     Setting.set(:response_headers_blacklist, blacklist)
   end
+
+  @doc """
+  Sets default cassette_defaults option
+  """
+  def cassette_defaults(cassette_defaults) do
+    Setting.set(:cassette_defaults, cassette_defaults)
+  end
 end

--- a/lib/exvcr/config_loader.ex
+++ b/lib/exvcr/config_loader.ex
@@ -36,5 +36,11 @@ defmodule ExVCR.ConfigLoader do
     else
       Config.response_headers_blacklist([])
     end
+
+    if env[:cassette_defaults] != nil do
+      Config.cassette_defaults(env[:cassette_defaults])
+    else
+      Config.cassette_defaults(Setting.get_default_cassette_defaults)
+    end
   end
 end

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -74,7 +74,7 @@ defmodule ExVCR.Mock do
   """
   defmacro use_cassette(fixture, test) do
     quote do
-      use_cassette(unquote(fixture), [], unquote(test))
+      use_cassette(unquote(fixture), unquote(ExVCR.Setting.get(:cassette_defaults)), unquote(test))
     end
   end
 

--- a/lib/exvcr/setting.ex
+++ b/lib/exvcr/setting.ex
@@ -6,6 +6,7 @@ defmodule ExVCR.Setting do
   @ets_table :exvcr_setting
   @default_vcr_path    "fixture/vcr_cassettes"
   @default_custom_path "fixture/custom_cassettes"
+  @default_cassette_defaults []
 
   def get(key) do
     setup
@@ -23,6 +24,7 @@ defmodule ExVCR.Setting do
 
   def get_default_vcr_path, do: @default_vcr_path
   def get_default_custom_path, do: @default_custom_path
+  def get_default_cassette_defaults, do: @default_cassette_defaults
 
   defp setup do
     if :ets.info(@ets_table) == :undefined do

--- a/test/config_loader_test.exs
+++ b/test/config_loader_test.exs
@@ -23,6 +23,7 @@ defmodule ExVCR.ConfigLoaderTest do
     ExVCR.Config.filter_sensitive_data("test_before1", "test_after1")
     ExVCR.Config.filter_url_params(true)
     ExVCR.Config.response_headers_blacklist(["Content-Type", "Accept"])
+    ExVCR.Config.cassette_defaults([:query, :request_body])
 
     # Load default values (defined in config/config.exs)
     ExVCR.ConfigLoader.load_defaults
@@ -32,6 +33,7 @@ defmodule ExVCR.ConfigLoaderTest do
     assert ExVCR.Setting.get(:custom_library_dir) == "fixture/custom_cassettes"
     assert ExVCR.Setting.get(:filter_url_params) == false
     assert ExVCR.Setting.get(:response_headers_blacklist) == []
+    assert ExVCR.Setting.get(:cassette_defaults) == []
   end
 
   test "loading default setting from empty values" do
@@ -40,12 +42,14 @@ defmodule ExVCR.ConfigLoaderTest do
     custom_cassette_library_dir = Application.get_env(:exvcr, :custom_cassette_library_dir)
     filter_sensitive_data       = Application.get_env(:exvcr, :filter_sensitive_data)
     response_headers_blacklist  = Application.get_env(:exvcr, :response_headers_blacklist)
+    cassette_defaults           = Application.get_env(:exvcr, :cassette_defaults)
 
     # Remove env values
     Application.delete_env(:exvcr, :vcr_cassette_library_dir)
     Application.delete_env(:exvcr, :custom_cassette_library_dir)
     Application.delete_env(:exvcr, :filter_sensitive_data)
     Application.delete_env(:exvcr, :response_headers_blacklist)
+    Application.delete_env(:exvcr, :cassette_defaults)
 
     # Load default values
     ExVCR.ConfigLoader.load_defaults
@@ -55,11 +59,13 @@ defmodule ExVCR.ConfigLoaderTest do
     assert ExVCR.Setting.get(:custom_library_dir) == "fixture/custom_cassettes"
     assert ExVCR.Setting.get(:filter_url_params) == false
     assert ExVCR.Setting.get(:response_headers_blacklist) == []
+    assert ExVCR.Setting.get(:cassette_defaults) == []
 
     # Restore env values
     Application.put_env(:exvcr, :vcr_cassette_library_dir, vcr_cassette_library_dir)
     Application.put_env(:exvcr, :custom_cassette_library_dir, custom_cassette_library_dir)
     Application.get_env(:exvcr, :filter_sensitive_data, filter_sensitive_data)
     Application.get_env(:exvcr, :response_headers_blacklist, response_headers_blacklist)
+    Application.get_env(:exvcr, :cassette_defaults, cassette_defaults)
   end
 end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -52,4 +52,12 @@ defmodule ExVCR.ConfigTest do
     ExVCR.Config.response_headers_blacklist([])
     assert ExVCR.Setting.get(:response_headers_blacklist) == []
   end
+
+  test "add cassette_defaults" do
+    ExVCR.Config.cassette_defaults([])
+    assert ExVCR.Setting.get(:cassette_defaults) == []
+
+    ExVCR.Config.cassette_defaults(match_requests_on: [:query, :request_body])
+    assert ExVCR.Setting.get(:cassette_defaults) == [match_requests_on: [:query, :request_body]]
+  end
 end

--- a/test/setting_test.exs
+++ b/test/setting_test.exs
@@ -27,4 +27,9 @@ defmodule ExVCR.SettingTest do
     ExVCR.Setting.set(:response_headers_blacklist, ["Content-Type", "Accept"])
     assert ExVCR.Setting.get(:response_headers_blacklist) == ["Content-Type", "Accept"]
   end
+
+  test "set cassette_defaults" do
+    ExVCR.Setting.set(:cassette_defaults, [match_requests_on: [:query, :request_body]])
+    assert ExVCR.Setting.get(:cassette_defaults) == [match_requests_on: [:query, :request_body]]
+  end
 end


### PR DESCRIPTION
Set default options for cassettes. This will allow people to do stuff like

``` elixir
config :exvcr, [
  cassette_defaults: [match_requests_on: [:query, :request_body]],
]
```
