### PR TITLE
Fix configuring cassette_library_dir

### DIFF
--- a/lib/exvcr/config.ex
+++ b/lib/exvcr/config.ex
@@ -12,8 +12,6 @@ defmodule ExVCR.Config do
   """
   def cassette_library_dir(vcr_dir, custom_dir \\ nil) do
     Setting.set(:cassette_library_dir, vcr_dir)
-    File.mkdir_p!(vcr_dir)
-
     Setting.set(:custom_library_dir, custom_dir)
     :ok
   end

--- a/lib/exvcr/json.ex
+++ b/lib/exvcr/json.ex
@@ -10,7 +10,7 @@ defmodule ExVCR.JSON do
     gunzipped_recordings = recordings
     |> Enum.map(&gunzip_recording/1)
     json = gunzipped_recordings |> Enum.reverse |> JSX.encode!
-    unless File.exists?(path = Path.dirname(file_name)), do: File.mkdir_p(path)
+    unless File.exists?(path = Path.dirname(file_name)), do: File.mkdir_p!(path)
     File.write!(file_name, JSX.prettify!(json))
   end
 


### PR DESCRIPTION
* when user of the app calls `cassette_library_dir/2`, that function is
  actually being called twice. 1st time because of
  ConfigLoader.load_defaults and 2nd time with the custom dir. Thus,
  calling `File.mkdir_p` inside `cassette_library_dir/2` with a custom
  dir, always created 2 dirs: the default one and the custom one

* it looks like this call isn't needed here, because `ExVCR.JSON.save/2`
  creates a directory when it doesn't exist

* Use `File.mkdir_p!` since we don't do explicit error handling