### PR TITLE
Convert cached status codes back into char lists

### DIFF
--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -48,6 +48,17 @@ defmodule ExVCR.Adapter.IBrowse do
     apply_filters(response)
   end
 
+  @doc """
+  Callback from ExVCR.Handler to get the response content tuple from the ExVCR.Reponse record.
+  """
+  def get_response_value_from_cache(response) do
+    if response.type == "error" do
+      {:error, response.body}
+    else
+      {:ok, Integer.to_char_list(response.status_code), response.headers, response.body}
+    end
+  end
+
   defp apply_filters({:ok, status_code, headers, body}) do
     replaced_body = to_string(body) |> ExVCR.Filter.filter_sensitive_data
     filtered_headers = ExVCR.Filter.remove_blacklisted_headers(headers)


### PR DESCRIPTION
Currently, for the ibrowse adapter, status codes are converted back into
char lists when loaded from a json file, but not when they're pulled
back out of the cache. If you cache a request and then immediately try
to use it (without writing it and reading it from a file) the status
code we get back from the ibrowse call will be an integer. This fixes
that and transforms all status codes back into char lists when pulled
directly from the cache.