### PR TITLE
Allow matching requests by headers

### DIFF
--- a/fixture/vcr_cassettes/different_headers_off.json
+++ b/fixture/vcr_cassettes/different_headers_off.json
@@ -1,0 +1,25 @@
+[
+  {
+    "request": {
+      "body": "p=3",
+      "headers": {
+        "User-Agent": "My App"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34006/server"
+    },
+    "response": {
+      "body": "test_response_before",
+      "headers": {
+        "connection": "keep-alive",
+        "server": "Cowboy",
+        "date": "Thu, 21 Apr 2016 17:52:30 GMT",
+        "content-length": "20"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/different_headers_on.json
+++ b/fixture/vcr_cassettes/different_headers_on.json
@@ -1,0 +1,25 @@
+[
+  {
+    "request": {
+      "body": "body",
+      "headers": {
+        "User-Agent": "My App"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34006/server"
+    },
+    "response": {
+      "body": "test_response_before",
+      "headers": {
+        "connection": "keep-alive",
+        "server": "Cowboy",
+        "date": "Thu, 21 Apr 2016 16:58:36 GMT",
+        "content-length": "20"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/different_headers_on.json
+++ b/fixture/vcr_cassettes/different_headers_on.json
@@ -15,8 +15,31 @@
       "headers": {
         "connection": "keep-alive",
         "server": "Cowboy",
-        "date": "Thu, 21 Apr 2016 16:58:36 GMT",
+        "date": "Thu, 21 Apr 2016 17:40:10 GMT",
         "content-length": "20"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "body",
+      "headers": {
+        "User-Agent": "Other App"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34006/server"
+    },
+    "response": {
+      "body": "test_response_after",
+      "headers": {
+        "connection": "keep-alive",
+        "server": "Cowboy",
+        "date": "Thu, 21 Apr 2016 17:40:10 GMT",
+        "content-length": "19"
       },
       "status_code": 200,
       "type": "ok"

--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -38,8 +38,10 @@ defmodule ExVCR.Adapter.Hackney do
     url    = Enum.fetch!(request, 1)
     method = Enum.fetch!(request, 0)
     request_body = Enum.fetch(request, 3) |> parse_request_body
+    headers = Enum.fetch!(request, 2)
+    |> Enum.map(fn {key, value} -> {to_string(key), to_string(value)} end)
 
-    [url: url, method: method, request_body: request_body]
+    [url: url, method: method, request_body: request_body, headers: headers]
   end
 
   @doc """

--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -5,6 +5,7 @@ defmodule ExVCR.Adapter.Hackney do
 
   use ExVCR.Adapter
   alias ExVCR.Adapter.Hackney.Store
+  alias ExVCR.Util
 
   defmacro __using__(_opts) do
     quote do
@@ -38,8 +39,7 @@ defmodule ExVCR.Adapter.Hackney do
     url    = Enum.fetch!(request, 1)
     method = Enum.fetch!(request, 0)
     request_body = Enum.fetch(request, 3) |> parse_request_body
-    headers = Enum.fetch!(request, 2)
-    |> Enum.map(fn {key, value} -> {to_string(key), to_string(value)} end)
+    headers = Enum.fetch!(request, 2) |> Util.stringify_keys
 
     [url: url, method: method, request_body: request_body, headers: headers]
   end

--- a/lib/exvcr/adapter/httpc.ex
+++ b/lib/exvcr/adapter/httpc.ex
@@ -36,12 +36,12 @@ defmodule ExVCR.Adapter.Httpc do
   """
   def generate_keys_for_request(request) do
     case request do
-      [method, {url, _} | _] ->
-        [url: url, method: method, request_body: nil]
-      [method, {url, _, _, body} | _] ->
-        [url: url, method: method, request_body: body]
+      [method, {url, headers} | _] ->
+        [url: url, method: method, request_body: nil, headers: headers]
+      [method, {url, headers, _, body} | _] ->
+        [url: url, method: method, request_body: body, headers: []]
       [url | _] ->
-        [url: url, method: :get, request_body: nil]
+        [url: url, method: :get, request_body: nil, headers: []]
     end
   end
 

--- a/lib/exvcr/adapter/httpc.ex
+++ b/lib/exvcr/adapter/httpc.ex
@@ -4,6 +4,7 @@ defmodule ExVCR.Adapter.Httpc do
   """
 
   use ExVCR.Adapter
+  alias ExVCR.Util
 
   defmacro __using__(_opts) do
     # do nothing
@@ -37,9 +38,9 @@ defmodule ExVCR.Adapter.Httpc do
   def generate_keys_for_request(request) do
     case request do
       [method, {url, headers} | _] ->
-        [url: url, method: method, request_body: nil, headers: headers]
+        [url: url, method: method, request_body: nil, headers: Util.stringify_keys(headers)]
       [method, {url, headers, _, body} | _] ->
-        [url: url, method: method, request_body: body, headers: []]
+        [url: url, method: method, request_body: body, headers: Util.stringify_keys(headers)]
       [url | _] ->
         [url: url, method: :get, request_body: nil, headers: []]
     end

--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -4,6 +4,7 @@ defmodule ExVCR.Adapter.IBrowse do
   """
 
   use ExVCR.Adapter
+  alias ExVCR.Util
 
   defmacro __using__(_opts) do
     # do nothing
@@ -37,13 +38,9 @@ defmodule ExVCR.Adapter.IBrowse do
     url    = Enum.fetch!(request, 0)
     method = Enum.fetch!(request, 2)
     request_body = Enum.fetch(request, 3) |> parse_request_body
-    headers = Enum.fetch!(request, 1) |> stringify_keys
+    headers = Enum.fetch!(request, 1) |> Util.stringify_keys
 
     [url: url, method: method, request_body: request_body, headers: headers]
-  end
-
-  defp stringify_keys(list) do
-    list |> Enum.map(fn {key, value} -> {to_string(key), to_string(value)} end)
   end
 
   @doc """

--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -37,8 +37,13 @@ defmodule ExVCR.Adapter.IBrowse do
     url    = Enum.fetch!(request, 0)
     method = Enum.fetch!(request, 2)
     request_body = Enum.fetch(request, 3) |> parse_request_body
+    headers = Enum.fetch!(request, 1) |> stringify_keys
 
-    [url: url, method: method, request_body: request_body]
+    [url: url, method: method, request_body: request_body, headers: headers]
+  end
+
+  defp stringify_keys(list) do
+    list |> Enum.map(fn {key, value} -> {to_string(key), to_string(value)} end)
   end
 
   @doc """

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -5,6 +5,7 @@ defmodule ExVCR.Handler do
 
   alias ExVCR.Recorder
   alias ExVCR.Actor.Options
+  alias ExVCR.Util
 
   @doc """
   Get response from either server or cache.
@@ -89,6 +90,7 @@ defmodule ExVCR.Handler do
     if has_match_requests_on(:headers, options) do
       response[:request].headers
       |> Enum.to_list
+      |> Util.stringify_keys
       |> Keyword.equal?(keys[:headers])
     else
       true

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -60,7 +60,10 @@ defmodule ExVCR.Handler do
   end
 
   defp match_response(response, keys, recorder_options) do
-    match_by_url(response, keys, recorder_options) and match_by_method(response, keys) and match_by_request_body(response, keys, recorder_options)
+    match_by_url(response, keys, recorder_options)
+      and match_by_method(response, keys)
+      and match_by_request_body(response, keys, recorder_options)
+      and match_by_headers(response, keys, recorder_options)
   end
 
   defp match_by_url(response, keys, recorder_options) do
@@ -79,6 +82,16 @@ defmodule ExVCR.Handler do
       key_url     = parse_url(key_url, recorder_options)
 
       request_url == key_url
+    end
+  end
+
+  defp match_by_headers(response, keys, options) do
+    if has_match_requests_on(:headers, options) do
+      response[:request].headers
+      |> Enum.to_list
+      |> Keyword.equal?(keys[:headers])
+    else
+      true
     end
   end
 

--- a/lib/exvcr/util.ex
+++ b/lib/exvcr/util.ex
@@ -9,4 +9,12 @@ defmodule ExVCR.Util do
   def uniq_id do
     :os.timestamp |> Tuple.to_list |> Enum.join("")
   end
+
+  @doc """
+  Returns a list of keyword list as strings.
+  """
+
+  def stringify_keys(list) do
+    list |> Enum.map(fn {key, value} -> {to_string(key), to_string(value)} end)
+  end
 end

--- a/lib/exvcr/util.ex
+++ b/lib/exvcr/util.ex
@@ -11,7 +11,7 @@ defmodule ExVCR.Util do
   end
 
   @doc """
-  Returns a list of keyword list as strings.
+  Takes a keyword lists and returns then as strings.
   """
 
   def stringify_keys(list) do

--- a/lib/exvcr/util.ex
+++ b/lib/exvcr/util.ex
@@ -11,7 +11,7 @@ defmodule ExVCR.Util do
   end
 
   @doc """
-  Takes a keyword lists and returns then as strings.
+  Takes a keyword lists and returns them as strings.
   """
 
   def stringify_keys(list) do

--- a/test/handler_options_test.exs
+++ b/test/handler_options_test.exs
@@ -139,5 +139,18 @@ defmodule ExVCR.Adapter.HandlerOptionsTest do
         HttpServer.stop(@port)
       end
     end
+
+    test "not specifying match_requests_on: [:headers] ignores headers" do
+      use_cassette "different_headers_off" do
+        HttpServer.start(path: "/server", port: @port, response: "test_response_before")
+        assert HTTPotion.post(@url, [body: "p=3", headers: ["User-Agent": "My App"]]).body =~ ~r/test_response_before/
+        HttpServer.stop(@port)
+
+        # this method call should be mocked as previous "test_response_before" response
+        HttpServer.start(path: "/server", port: @port, response: "test_response_after")
+        assert HTTPotion.post(@url, [body: "p=4", headers: ["User-Agent": "Other App"]]).body =~ ~r/test_response_before/
+        HttpServer.stop(@port)
+      end
+    end
   end
 end

--- a/test/handler_options_test.exs
+++ b/test/handler_options_test.exs
@@ -126,5 +126,18 @@ defmodule ExVCR.Adapter.HandlerOptionsTest do
         HttpServer.stop(@port)
       end
     end
+
+    test "specifying match_requests_on: [:headers] matches header params" do
+      use_cassette "different_headers_on", match_requests_on: [:headers] do
+        HttpServer.start(path: "/server", port: @port, response: "test_response_before")
+        assert HTTPotion.post(@url, [body: "body", headers: ["User-Agent": "My App"]]).body =~ ~r/test_response_before/
+        HttpServer.stop(@port)
+
+        # this method call should NOT be mocked as previous "test_response_before" response
+        HttpServer.start(path: "/server", port: @port, response: "test_response_after")
+        assert HTTPotion.post(@url, [body: "body", headers: ["User-Agent": "Other App"]]).body =~ ~r/test_response_after/
+        HttpServer.stop(@port)
+      end
+    end
   end
 end


### PR DESCRIPTION
A lot of apps authenticate via a token in the headers. We ran into an issue where exvcr would not allow us to make a request to the same endpoint as a different user and verify different results. This adds the support to allow matching by headers.

I'm happy to take any feedback. Please let me know if there is anything missing.