### PR TITLE
Fix cached status code for ibrowse

### DIFF
--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -55,7 +55,14 @@ defmodule ExVCR.Adapter.IBrowse do
     if response.type == "error" do
       {:error, response.body}
     else
-      {:ok, Integer.to_char_list(response.status_code), response.headers, response.body}
+      status_code = case response.status_code do
+        integer when is_integer(integer) ->
+          Integer.to_char_list(integer)
+        char_list when is_list(char_list) ->
+          char_list
+      end
+
+      {:ok, status_code, response.headers, response.body}
     end
   end
 

--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -48,6 +48,17 @@ defmodule ExVCR.Adapter.IBrowse do
     apply_filters(response)
   end
 
+  @doc """
+  Callback from ExVCR.Handler to get the response content tuple from the ExVCR.Reponse record.
+  """
+  def get_response_value_from_cache(response) do
+    if response.type == "error" do
+      {:error, response.body}
+    else
+      {:ok, Integer.to_char_list(response.status_code), response.headers, response.body}
+    end
+  end
+
   defp apply_filters({:ok, status_code, headers, body}) do
     replaced_body = to_string(body) |> ExVCR.Filter.filter_sensitive_data
     filtered_headers = ExVCR.Filter.remove_blacklisted_headers(headers)


### PR DESCRIPTION
Before storing a response in the cache, `convert_to_string` is called which, for ibrowse, converts the status code from a char list to an integer. This is usually fine, unless you're making the same api request when recording a single cassette. On the second request, the response is grabbed from the cache and passed to ibrowse to return to the user. But, since the stored response has been converted from it's original tuple of char lists, ibrowse returns a response HTTPotion is not expecting, an integer status_code instead of a char list. This might be better solved by changing the representation of the response in the cache, but this fixed the immediate bug we hit in our tests.