### PR TITLE
Ensure blacklist header check is case insensitive.

### DIFF
--- a/lib/exvcr/filter.ex
+++ b/lib/exvcr/filter.ex
@@ -47,7 +47,7 @@ defmodule ExVCR.Filter do
 
   defp is_header_allowed?(header_name) do
     Enum.find(ExVCR.Setting.get(:response_headers_blacklist), fn(x) ->
-      to_string(header_name) == x
+      String.downcase(to_string(header_name)) == x
     end) == nil
   end
 end

--- a/test/filter_test.exs
+++ b/test/filter_test.exs
@@ -1,0 +1,14 @@
+defmodule ExVCR.FilterTest do
+  use ExUnit.Case, async: false
+
+  test "remove_blacklisted_headers with empty headers" do
+    assert ExVCR.Filter.remove_blacklisted_headers([]) == []
+  end
+
+  test "remove_blacklisted_headers with supplied headers" do
+    ExVCR.Config.response_headers_blacklist(["X-Filter1", "X-Filter2"])
+    headers = [{"X-Filter1", "1"}, {"x-filter2", "2"}, {"X-NoFilter", "3"}]
+    filtered_headers = ExVCR.Filter.remove_blacklisted_headers(headers)
+    assert filtered_headers == [{"X-NoFilter", "3"}]
+  end
+end


### PR DESCRIPTION
I was looking at a package that uses ExVCR and noticed that the cassettes were not filtering the headers that were specified in the config. It turns out to be a case sensitivity issue. I think it doesn't show up in the ExVCR specs because the test server, HttpServer, seems to use all lowercase headers.

I also noticed there is not a unit test file for `ExVCR.Filter`. I added one, but only added tests for the `remove_blacklisted_headers` method for now.

P.S. This is my first Elixir PR, apologies if I'm not following proper conventions yet. 😊 I'll be happy to fix mistakes.