### PR TITLE
Exclude `:stub` mode from applying `match_requests_on: [:request_body]` by default

### DIFF
--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -114,7 +114,7 @@ defmodule ExVCR.Handler do
   end
 
   defp match_by_request_body(response, params, options) do
-    if options[:stub] != nil || has_match_requests_on(:request_body, options) do
+    if has_match_requests_on(:request_body, options) do
       (response[:request].body || response[:request].request_body) ==
         params[:request_body] |> to_string
     else


### PR DESCRIPTION
Hi @parroty! Looks like it's impossible to disable check for request_body in stub mode.
Maybe just disable it by default?
