### PR TITLE
Include request info when NotMatchError occurs

### DIFF
--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -130,7 +130,7 @@ defmodule ExVCR.Handler do
   end
 
   defp get_response_from_server(request, recorder) do
-    raise_error_if_cassette_already_exists(recorder)
+    raise_error_if_cassette_already_exists(recorder, inspect(request))
     adapter = ExVCR.Recorder.options(recorder)[:adapter]
     response = :meck.passthrough(request)
                |> adapter.hook_response_from_server
@@ -139,12 +139,14 @@ defmodule ExVCR.Handler do
     response
   end
 
-  defp raise_error_if_cassette_already_exists(recorder) do
+  defp raise_error_if_cassette_already_exists(recorder, request_description) do
     file_path = ExVCR.Recorder.get_file_path(recorder)
     if File.exists?(file_path) do
       message = """
       Request did not match with any one in the current cassette: #{file_path}.
       Delete the current cassette with [mix vcr.delete] and re-record.
+
+      Request: #{request_description}
       """
       raise ExVCR.RequestNotMatchError, message: message
     end

--- a/test/adapter_ibrowse_test.exs
+++ b/test/adapter_ibrowse_test.exs
@@ -93,7 +93,7 @@ defmodule ExVCR.Adapter.IBrowseTest do
     end
 
     use_cassette "example_ibrowse_different" do
-      assert_raise ExVCR.RequestNotMatchError, fn ->
+      assert_raise ExVCR.RequestNotMatchError, ~r/different_from_original/, fn ->
         :ibrowse.send_req('http://example.com/different_from_original', [], :get)
       end
     end


### PR DESCRIPTION
## Problem
When investigating `RequestNotMatchError` exceptions, it can be hard to see where the problem is. The best approach _seems_ to be to move your cassettes to one side, re-run the test, then diff the new and old cassettes to see where the change it.

This is a pretty slow and laborious developer experience.

## Solution
Include some basic information about the request which didn't match anything in the active cassette, to help the developer zero in on where the problem is.

Example message:

```
Request did not match with any one in the current cassette: fixture/vcr_cassettes/example_ibrowse_different.json.
Delete the current cassette with [mix vcr.delete] and re-record.

Request: ['http://example.com/different_from_original', [], :get]
```

If there's a better way to format the request in a human-friendly way, let me know!