### PR TITLE
Remove elixir 1.4 deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: elixir
 elixir:
   - 1.2.6
-  - 1.3.2
+  - 1.3.4
+  - 1.4.0
 otp_release:
   - 18.1
 script:

--- a/lib/exvcr/converter.ex
+++ b/lib/exvcr/converter.ex
@@ -21,42 +21,42 @@ defmodule ExVCR.Converter do
       end
       defoverridable [convert_to_string: 2]
 
-      defp string_to_request(string) do
+      def string_to_request(string) do
         request = Enum.map(string, fn({x,y}) -> {String.to_atom(x),y} end) |> Enum.into(%{})
         struct(ExVCR.Request, request)
       end
       defoverridable [string_to_request: 1]
 
-      defp string_to_response(string), do: raise ExVCR.ImplementationMissingError
+      def string_to_response(string), do: raise ExVCR.ImplementationMissingError
       defoverridable [string_to_response: 1]
 
-      defp request_to_string(request), do: raise ExVCR.ImplementationMissingError
+      def request_to_string(request), do: raise ExVCR.ImplementationMissingError
       defoverridable [request_to_string: 1]
 
-      defp response_to_string(response), do: raise ExVCR.ImplementationMissingError
+      def response_to_string(response), do: raise ExVCR.ImplementationMissingError
       defoverridable [response_to_string: 1]
 
-      defp parse_headers(headers) do
+      def parse_headers(headers) do
         do_parse_headers(headers, [])
       end
       defoverridable [parse_headers: 1]
 
-      defp do_parse_headers([], acc) do
+      def do_parse_headers([], acc) do
         Enum.reverse(acc) |> Enum.uniq(fn({key,value}) -> key end)
       end
-      defp do_parse_headers([{key,value}|tail], acc) do
+      def do_parse_headers([{key,value}|tail], acc) do
         replaced_value = to_string(value) |> ExVCR.Filter.filter_sensitive_data
         replaced_value = ExVCR.Filter.filter_request_header(to_string(key), to_string(replaced_value))
         do_parse_headers(tail, [{to_string(key), replaced_value}|acc])
       end
       defoverridable [do_parse_headers: 2]
 
-      defp parse_url(url) do
+      def parse_url(url) do
         to_string(url) |> ExVCR.Filter.filter_url_params
       end
       defoverridable [parse_url: 1]
 
-      defp parse_keyword_list(params) do
+      def parse_keyword_list(params) do
         Enum.map(params, fn({k,v}) -> {k,to_string(v)} end)
       end
       defoverridable [parse_keyword_list: 1]

--- a/lib/exvcr/converter.ex
+++ b/lib/exvcr/converter.ex
@@ -42,7 +42,7 @@ defmodule ExVCR.Converter do
       defoverridable [parse_headers: 1]
 
       def do_parse_headers([], acc) do
-        Enum.reverse(acc) |> Enum.uniq(fn({key,value}) -> key end)
+        Enum.reverse(acc) |> Enum.uniq_by(fn({key,value}) -> key end)
       end
       def do_parse_headers([{key,value}|tail], acc) do
         replaced_value = to_string(value) |> ExVCR.Filter.filter_sensitive_data


### PR DESCRIPTION
Elixir 1.4 deprecates the use of `defoverridable` with private functions and recommends using `Enum.uniq_by/2` instead of `Enum.uniq/2`.

This was adding a fair bit of noise to my test suite after upgrading, so assuming this is merged it might be good to get a new version released so others don't run into it.