### PR TITLE
Tidy up the applications list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule ExVCR.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [ applications: [:http_server] ]
+    [applications: [:meck, :exactor, :exjsx]]
   end
 
   # Returns the list of dependencies in the format:


### PR DESCRIPTION
Not all applications you depend on were specified and
applications that you require only in dev/test were listed.

I have not verified this is correct but it is a push in the
right direction. Please read this blog post for more information:
http://blog.plataformatec.com.br/2016/07/understanding-deps-and-applications-in-your-mixfile/

This may break the test suite but you can fix it by calling
`Application.ensure_all_started(:http_server)` in your
test_helper.exs.