### PR TITLE
Load configuration for cassette paths for mix tasks

### DIFF
--- a/lib/exvcr/config_loader.ex
+++ b/lib/exvcr/config_loader.ex
@@ -3,6 +3,9 @@ defmodule ExVCR.ConfigLoader do
   Load configuration parameters from config.exs.
   """
 
+  @default_vcr_path    "fixture/vcr_cassettes"
+  @default_custom_path "fixture/custom_cassettes"
+
   alias ExVCR.Config
   alias ExVCR.Setting
 
@@ -17,7 +20,7 @@ defmodule ExVCR.ConfigLoader do
         env[:vcr_cassette_library_dir], env[:custom_cassette_library_dir])
     else
       Config.cassette_library_dir(
-        Setting.get_default_vcr_path, Setting.get_default_custom_path)
+        @default_vcr_path, @default_custom_path)
     end
 
     Config.filter_sensitive_data(nil) # reset to empty list

--- a/lib/exvcr/setting.ex
+++ b/lib/exvcr/setting.ex
@@ -4,8 +4,7 @@ defmodule ExVCR.Setting do
   """
 
   @ets_table :exvcr_setting
-  @default_vcr_path    "fixture/vcr_cassettes"
-  @default_custom_path "fixture/custom_cassettes"
+
 
   def get(key) do
     setup()
@@ -20,9 +19,6 @@ defmodule ExVCR.Setting do
   def append(key, value) do
     set(key, [value | ExVCR.Setting.get(key)])
   end
-
-  def get_default_vcr_path, do: @default_vcr_path
-  def get_default_custom_path, do: @default_custom_path
 
   defp setup do
     if :ets.info(@ets_table) == :undefined do

--- a/lib/exvcr/task/util.ex
+++ b/lib/exvcr/task/util.ex
@@ -7,8 +7,8 @@ defmodule ExVCR.Task.Util do
   Parse basic option parameters, which are commonly used by multiple mix tasks.
   """
   def parse_basic_options(options) do
-    [ options[:dir]    || ExVCR.Setting.get_default_vcr_path,
-      options[:custom] || ExVCR.Setting.get_default_custom_path ]
+    [ options[:dir]    || ExVCR.Setting.get(:cassette_library_dir),
+      options[:custom] || ExVCR.Setting.get(:custom_library_dir) ]
   end
 
   @doc """

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Vcr do
 
       if pattern do
         ExVCR.Task.Runner.delete_cassettes(
-          options[:dir] || ExVCR.Setting.get(:cassette_library_path),
+          options[:dir] || ExVCR.Setting.get(:cassette_library_dir),
           pattern, options[:interactive] || false)
       else
         IO.puts "[Invalid Param] Specify substring of cassette file-name to be deleted - `mix vcr.delete [pattern]`, or use `mix vcr.delete --all` for deleting all cassettes."

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.Vcr do
 
       if pattern do
         ExVCR.Task.Runner.delete_cassettes(
-          options[:dir] || ExVCR.Setting.get_default_vcr_path,
+          options[:dir] || ExVCR.Setting.get(:cassette_library_path),
           pattern, options[:interactive] || false)
       else
         IO.puts "[Invalid Param] Specify substring of cassette file-name to be deleted - `mix vcr.delete [pattern]`, or use `mix vcr.delete --all` for deleting all cassettes."


### PR DESCRIPTION
## The Problem

When running the `Mix` tasks defined in this project, they would only use the hard-coded default paths for recorded and custom cassettes and not consider the config. This demonstrates different configuration behavior between managing cassette data when running tests and managing cassette data from mix tasks.

## Proposed Changes

These changes now look at the `Mix.Config` related to `exvcr` and use those directories if they are not specified on the CLI and then fallback to the defaults if a custom config is not used in both the context of the project's `Mix` tasks and running tests.

## References

Related to Issue https://github.com/parroty/exvcr/issues/82