### PR TITLE
Add support for HEAD request in hackney

### DIFF
--- a/fixture/vcr_cassettes/hackney_head.json
+++ b/fixture/vcr_cassettes/hackney_head.json
@@ -1,0 +1,31 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "head",
+      "options": [],
+      "request_body": "",
+      "url": "http://www.example.com"
+    },
+    "response": {
+      "body": null,
+      "headers": {
+        "Content-Encoding": "gzip",
+        "Accept-Ranges": "bytes",
+        "Cache-Control": "max-age=604800",
+        "Content-Type": "text/html",
+        "Date": "Fri, 27 Jan 2017 12:44:46 GMT",
+        "Etag": "\"359670651+gzip\"",
+        "Expires": "Fri, 03 Feb 2017 12:44:46 GMT",
+        "Last-Modified": "Fri, 09 Aug 2013 23:54:35 GMT",
+        "Server": "ECS (ewr/15BD)",
+        "X-Cache": "HIT",
+        "x-ec-custom-error": "1",
+        "Content-Length": "606"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/httpoison_head.json
+++ b/fixture/vcr_cassettes/httpoison_head.json
@@ -1,0 +1,31 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "head",
+      "options": [],
+      "request_body": "",
+      "url": "http://example.com"
+    },
+    "response": {
+      "body": null,
+      "headers": {
+        "Content-Encoding": "gzip",
+        "Accept-Ranges": "bytes",
+        "Cache-Control": "max-age=604800",
+        "Content-Type": "text/html",
+        "Date": "Fri, 27 Jan 2017 12:44:45 GMT",
+        "Etag": "\"359670651+gzip\"",
+        "Expires": "Fri, 03 Feb 2017 12:44:45 GMT",
+        "Last-Modified": "Fri, 09 Aug 2013 23:54:35 GMT",
+        "Server": "ECS (ewr/15BD)",
+        "X-Cache": "HIT",
+        "x-ec-custom-error": "1",
+        "Content-Length": "606"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/exvcr/adapter/hackney/converter.ex
+++ b/lib/exvcr/adapter/hackney/converter.ex
@@ -59,6 +59,14 @@ defmodule ExVCR.Adapter.Hackney.Converter do
     }
   end
 
+  defp response_to_string({:ok, status_code, headers}) do
+    %ExVCR.Response{
+      type: "ok",
+      status_code: status_code,
+      headers: parse_headers(headers)
+    }
+  end
+
   defp response_to_string({:error, reason}) do
     %ExVCR.Response{
       type: "error",

--- a/test/adapter_hackney_test.exs
+++ b/test/adapter_hackney_test.exs
@@ -17,6 +17,14 @@ defmodule ExVCR.Adapter.HackneyTest do
     end
   end
 
+  test "hackney head request" do
+    use_cassette "hackney_head" do
+      {:ok, status_code, headers} = :hackney.request(:head, "http://www.example.com", [], [], [])
+      assert status_code == 200
+      assert List.keyfind(headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+    end
+  end
+
   test "hackney request with gzipped response" do
     use_cassette "hackney_get_gzipped" do
       headers = [{"Accept-Encoding", "gzip, deflate"}]
@@ -77,6 +85,15 @@ defmodule ExVCR.Adapter.HackneyTest do
       response = HTTPoison.get!("http://example.com", [], [hackney: [basic_auth: {"user", "password"}]])
       assert response.body =~ ~r/Example Domain/
       assert response.status_code == 200
+    end
+  end
+
+  test "head request" do
+    use_cassette "httpoison_head" do
+      response = HTTPoison.head!("http://example.com")
+      assert response.body == ""
+      assert response.status_code == 200
+      assert List.keyfind(response.headers, "Content-Type", 0) == {"Content-Type", "text/html"}
     end
   end
 


### PR DESCRIPTION
This allows use of HEAD requests from hackney or HTTPoison, addressing #83, which I also have been experiencing.

(HEAD requests have no body, so I had to add some pattern matching to handle circumstances when the body was `nil`.)

Please let me know what you think!