### PR TITLE
Allow cache to be skipped when running a cassette

### DIFF
--- a/fixture/vcr_cassettes/skips_cache.json
+++ b/fixture/vcr_cassettes/skips_cache.json
@@ -1,0 +1,78 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": []
+      },
+      "request_body": "",
+      "url": "https://www.random.org/integers/?num=1&min=1&max=10000&col=1&base=10&format=plain&rnd=new"
+    },
+    "response": {
+      "body": "4361\n",
+      "headers": {
+        "cache-control": "no-store, no-cache, must-revalidate, post-check=0, pre-check=0",
+        "connection": "keep-alive",
+        "date": "Tue, 25 Apr 2017 12:35:08 GMT",
+        "pragma": "no-cache",
+        "server": "cloudflare-nginx",
+        "vary": "Accept-Encoding",
+        "content-length": "5",
+        "content-type": "text/plain;charset=utf-8",
+        "expires": "Thu, 19 Nov 1981 08:52:00 GMT",
+        "set-cookie": "__cfduid=deb9bced1f4126e4ccb6afbe9d52c8fc91493123707; expires=Wed, 25-Apr-18 12:35:07 GMT; path=/; domain=.random.org; HttpOnly",
+        "x-powered-by": "PHP/5.4.45-0+deb7u8",
+        "rdo-authenticated-login": "-",
+        "access-control-allow-origin": "*",
+        "cf-ray": "355157266dc729a5-DUB"
+      },
+      "status_code": [
+        "HTTP/1.1",
+        200,
+        "OK"
+      ],
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": []
+      },
+      "request_body": "",
+      "url": "https://www.random.org/integers/?num=1&min=1&max=10000&col=1&base=10&format=plain&rnd=new"
+    },
+    "response": {
+      "body": "8497\n",
+      "headers": {
+        "cache-control": "no-store, no-cache, must-revalidate, post-check=0, pre-check=0",
+        "connection": "keep-alive",
+        "date": "Tue, 25 Apr 2017 12:35:09 GMT",
+        "pragma": "no-cache",
+        "server": "cloudflare-nginx",
+        "vary": "Accept-Encoding",
+        "content-length": "5",
+        "content-type": "text/plain;charset=utf-8",
+        "expires": "Thu, 19 Nov 1981 08:52:00 GMT",
+        "set-cookie": "__cfduid=d33aab74e06d24dff4ae23de0b0be86f91493123708; expires=Wed, 25-Apr-18 12:35:08 GMT; path=/; domain=.random.org; HttpOnly",
+        "x-powered-by": "PHP/5.4.45-0+deb7u8",
+        "rdo-authenticated-login": "-",
+        "access-control-allow-origin": "*",
+        "cf-ray": "3551572a8fcb29a5-DUB"
+      },
+      "status_code": [
+        "HTTP/1.1",
+        200,
+        "OK"
+      ],
+      "type": "ok"
+    }
+  }
+]

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -11,7 +11,13 @@ defmodule ExVCR.Handler do
   Get response from either server or cache.
   """
   def get_response(recorder, request) do
-    get_response_from_cache(request, recorder) || get_response_from_server(request, recorder)
+    recorder_options = Options.get(recorder.options)
+
+    if recorder_options[:skip_cache] do
+      get_response_from_server(request, recorder)
+    else
+      get_response_from_cache(request, recorder) || get_response_from_server(request, recorder)
+    end
   end
 
   @doc """

--- a/test/skip_cache_test.exs
+++ b/test/skip_cache_test.exs
@@ -1,0 +1,46 @@
+defmodule ExVCR.SkipCacheTest do
+  use ExUnit.Case, async: false
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Httpc
+  alias ExVCR.Recorder
+  alias ExVCR.Mock
+  alias ExVCR.Actor.Responses
+
+  test "skips cache when the skip_cache option is passed" do
+    recorder = Recorder.start([skip_cache: true, fixture: "stubbed_request", adapter: ExVCR.Adapter.Httpc])
+    Mock.mock_methods(recorder, ExVCR.Adapter.Httpc)
+
+    [first_body, second_body] = make_random_requests()
+
+    responses = Responses.get(recorder.responses)
+
+    assert first_body != second_body
+    assert Enum.count(responses) == 2
+  end
+
+  test "relies on cache during record when skip_cache is not passed" do
+    recorder = Recorder.start([fixture: "stubbed_request", adapter: ExVCR.Adapter.Httpc])
+    Mock.mock_methods(recorder, ExVCR.Adapter.Httpc)
+
+    [first_body, second_body] = make_random_requests()
+
+    responses = Responses.get(recorder.responses)
+
+    assert first_body == second_body
+    assert Enum.count(responses) == 1
+  end
+
+  test "uses the correct responses when recorded with skip_cache enabled" do
+    use_cassette "skips_cache" do
+      [first_body, second_body] = make_random_requests()
+      assert first_body != second_body
+    end
+  end
+
+  defp make_random_requests do
+    random_url = 'https://www.random.org/integers/?num=1&min=1&max=10000&col=1&base=10&format=plain&rnd=new'
+    {:ok, {_res, _headers, first_body}} = :httpc.request(random_url)
+    {:ok, {_res, _headers, second_body}} = :httpc.request(random_url)
+
+    [first_body, second_body]
+  end
+end


### PR DESCRIPTION
Adds a `skip_cache` option which can be passed to `use_cassette`, which will
prevent cache from being for requests within the cassette, but will still record
the responses for each. If the option is removed after recording, subsequent
runs will use the correct responses.