### PR TITLE
Adding filter_request_options to filter sensitive data in request options

### DIFF
--- a/lib/exvcr/adapter/hackney/converter.ex
+++ b/lib/exvcr/adapter/hackney/converter.ex
@@ -26,7 +26,7 @@ defmodule ExVCR.Adapter.Hackney.Converter do
       headers: parse_headers(headers),
       method: to_string(method),
       body: parse_request_body(body),
-      options: sanitize_options(options)
+      options: parse_options(sanitize_options(options))
     }
   end
 

--- a/lib/exvcr/adapter/ibrowse/converter.ex
+++ b/lib/exvcr/adapter/ibrowse/converter.ex
@@ -49,7 +49,7 @@ defmodule ExVCR.Adapter.IBrowse.Converter do
       headers: parse_headers(headers),
       method: Atom.to_string(method),
       body: parse_request_body(body),
-      options: sanitize_options(options)
+      options: parse_options(sanitize_options(options))
     }
   end
 

--- a/lib/exvcr/config.ex
+++ b/lib/exvcr/config.ex
@@ -48,6 +48,21 @@ defmodule ExVCR.Config do
   end
 
   @doc """
+  Clear the previously specified filter_request_options lists.
+  """
+  def filter_request_options(nil) do
+    Setting.set(:filter_request_options, [])
+  end
+
+  @doc """
+  Replace the specified request header with placeholder.
+  It can be used to remove sensitive data from the casette file.
+  """
+  def filter_request_options(header) do
+    Setting.append(:filter_request_options, header)
+  end
+
+  @doc """
   Set the flag whether to filter-out url params when recording to cassettes.
   (ex. if flag is true, "param=val" is removed from "http://example.com?param=val").
   """

--- a/lib/exvcr/config_loader.ex
+++ b/lib/exvcr/config_loader.ex
@@ -36,6 +36,13 @@ defmodule ExVCR.ConfigLoader do
       end)
     end
 
+    Config.filter_request_options(nil) # reset to empty list
+    if env[:filter_request_options] != nil do
+      Enum.each(env[:filter_request_options], fn(option) ->
+        Config.filter_request_options(option)
+      end)
+    end
+
     if env[:filter_url_params] != nil do
       Config.filter_url_params(env[:filter_url_params])
     end

--- a/lib/exvcr/converter.ex
+++ b/lib/exvcr/converter.ex
@@ -51,6 +51,21 @@ defmodule ExVCR.Converter do
       end
       defoverridable [do_parse_headers: 2]
 
+      def parse_options(options) do
+        do_parse_options(options, [])
+      end
+      defoverridable [parse_options: 1]
+
+      def do_parse_options([], acc) do
+        Enum.reverse(acc) |> Enum.uniq_by(fn({key,value}) -> key end)
+      end
+      def do_parse_options([{key,value}|tail], acc) do
+        replaced_value = to_string(value) |> ExVCR.Filter.filter_sensitive_data
+        replaced_value = ExVCR.Filter.filter_request_option(to_string(key), to_string(replaced_value))
+        do_parse_options(tail, [{to_string(key), replaced_value}|acc])
+      end
+      defoverridable [do_parse_options: 2]
+
       def parse_url(url) do
         to_string(url) |> ExVCR.Filter.filter_url_params
       end

--- a/lib/exvcr/filter.ex
+++ b/lib/exvcr/filter.ex
@@ -17,6 +17,13 @@ defmodule ExVCR.Filter do
     if Enum.member?(ExVCR.Setting.get(:filter_request_headers), header), do: "***", else: value
   end
 
+  @doc """
+  Filter out senstive data from the request options.
+  """
+  def filter_request_option(option, value) do
+    if Enum.member?(ExVCR.Setting.get(:filter_request_options), option), do: "***", else: value
+  end
+
   defp replace(body, []), do: body
   defp replace(body, [{pattern, placeholder}|tail]) do
     replace(String.replace(body, ~r/#{pattern}/, placeholder), tail)

--- a/test/recorder_hackney_test.exs
+++ b/test/recorder_hackney_test.exs
@@ -83,6 +83,21 @@ defmodule ExVCR.RecorderHackneyTest do
     ExVCR.Config.filter_request_headers(nil)
   end
 
+  test "replace sensitive data in request options" do
+    ExVCR.Config.filter_request_options("basic_auth")
+    use_cassette "sensitive_data_in_request_options" do
+      body = HTTPoison.get!(@url, [], [hackney: [basic_auth: {"username", "password"}]]).body
+      assert body == "test_response"
+    end
+
+    # The recorded cassette should contain replaced data.
+    cassette = File.read!("#{@dummy_cassette_dir}/sensitive_data_in_request_options.json")
+    assert cassette =~ "\"basic_auth\": \"***\""
+    refute cassette =~  "\"basic_auth\": {\"username\", \"password\"}"
+
+    ExVCR.Config.filter_request_options(nil)
+  end
+
   test "filter url param flag removes url params when recording cassettes" do
     ExVCR.Config.filter_url_params(true)
     use_cassette "example_ignore_url_params" do

--- a/test/recorder_ibrowse_test.exs
+++ b/test/recorder_ibrowse_test.exs
@@ -80,6 +80,20 @@ defmodule ExVCR.RecorderIBrowseTest do
     ExVCR.Config.filter_request_headers(nil)
   end
 
+  test "replace sensitive data in request options" do
+    ExVCR.Config.filter_request_options("basic_auth")
+    use_cassette "sensitive_data_in_request_options" do
+      assert HTTPotion.get(@url_with_query, [basic_auth: {"username", "password"}]).body =~ ~r/test_response/
+    end
+
+    # The recorded cassette should contain replaced data.
+    cassette = File.read!("#{@dummy_cassette_dir}/sensitive_data_in_request_options.json")
+    assert cassette =~ "\"basic_auth\": \"***\""
+    refute cassette =~  "\"basic_auth\": {\"username\", \"password\"}"
+
+    ExVCR.Config.filter_request_options(nil)
+  end
+
   test "filter url param flag removes url params when recording cassettes" do
     ExVCR.Config.filter_url_params(true)
     use_cassette "example_ignore_url_params" do


### PR DESCRIPTION
Hi,
I was using exvcr for a project that needs to connect to an external API using basic_auth to get a cookie (and then use that cookie for all the consequent requests).
Using HTTPoison and hackney, I have to pass the basic_auth parameters trough the options and I discovered it was impossible to filter those data.

Hope this PR is useful for others too :)

Emanuel