### PR TITLE
Adds filter_request_headers to default parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ config :exvcr, [
     [pattern: "<PASSWORD>.+</PASSWORD>", placeholder: "PASSWORD_PLACEHOLDER"]
   ],
   filter_url_params: false,
+  filter_request_headers: [],
   response_headers_blacklist: []
 ]
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,5 +7,6 @@ config :exvcr, [
     [pattern: "<PASSWORD>.+</PASSWORD>", placeholder: "PASSWORD_PLACEHOLDER"]
   ],
   filter_url_params: false,
+  filter_request_headers: [],
   response_headers_blacklist: []
 ]


### PR DESCRIPTION
Setting `filter_request_headers` on `config.exs` is currently working and is a nicer alternative to explicitly setting `ExVCR.Config.filter_request_headers("X-My-Secret-Token")` in the test files.

This PR adds the option to the default `config.exs` and to the README file.