### PR TITLE
!! Ensure clear_mock runs after each test

### DIFF
--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -37,12 +37,11 @@ defmodule ExVCR.Mock do
 
       try do
         [do: return_value] = unquote(test)
+        return_value
+      after
         if options_method()[:clear_mock] || unquote(options)[:clear_mock] do
           :meck.unload(adapter_method().module_name)
         end
-        return_value
-      after
-        # do nothing
       end
     end
   end
@@ -59,11 +58,11 @@ defmodule ExVCR.Mock do
 
       try do
         [do: return_value] = unquote(test)
+        return_value
+      after
         if options_method()[:clear_mock] || unquote(options)[:clear_mock] do
           :meck.unload(adapter_method().module_name)
         end
-        return_value
-      after
         Recorder.save(recorder)
       end
     end

--- a/test/handler_options_test.exs
+++ b/test/handler_options_test.exs
@@ -61,6 +61,22 @@ defmodule ExVCR.Adapter.HandlerOptionsTest do
         assert HTTPotion.get(@url, []).body == "test_response1"
       end
     end
+
+    test "clear_mock option works even when exceptions are raised" do
+      # Force an exception to be raised
+      try do
+        use_cassette "option_clean_each", clear_mock: true do
+          assert false
+        end
+      rescue
+        _e in ExUnit.AssertionError -> nil
+      end
+
+      HttpServer.start(path: "/server", port: @port, response: "test_response2")
+      :timer.sleep(100) # put short sleep.
+      assert HTTPotion.get(@url, []).body == "test_response2"
+      HttpServer.stop(@port)
+    end
   end
 
   defmodule MatchRequestsOn do


### PR DESCRIPTION
In master, any failing spec raises ExUnit.AssertionError.  So any exvcr test that fails will skip clearing the mock, which then breaks all subsequent tests because they're running with another test's cassette.

I just moved your clear code into the after block to resolve, and added a test to verify.