### PR TITLE
Address deprecations

### DIFF
--- a/lib/exvcr/adapter/httpc/converter.ex
+++ b/lib/exvcr/adapter/httpc/converter.ex
@@ -30,7 +30,7 @@ defmodule ExVCR.Adapter.Httpc.Converter do
       if is_map(response.headers) do
         headers = response.headers
                   |> Map.to_list
-                  |> Enum.map(fn({k,v}) -> {to_char_list(k), to_char_list(v)} end)
+                  |> Enum.map(fn({k,v}) -> {to_charlist(k), to_charlist(v)} end)
         %{response | headers: headers}
       else
         response
@@ -41,7 +41,7 @@ defmodule ExVCR.Adapter.Httpc.Converter do
 
   defp convert_string_to_char_list(elem) do
     if is_binary(elem) do
-      to_char_list(elem)
+      to_charlist(elem)
     else
       elem
     end

--- a/lib/exvcr/adapter/httpc/converter.ex
+++ b/lib/exvcr/adapter/httpc/converter.ex
@@ -12,7 +12,7 @@ defmodule ExVCR.Adapter.Httpc.Converter do
     response =
       if response.status_code do
         status_code = response.status_code
-                      |> Enum.map(&convert_string_to_char_list/1)
+                      |> Enum.map(&convert_string_to_charlist/1)
                       |> List.to_tuple
         %{response | status_code: status_code}
       else
@@ -39,7 +39,7 @@ defmodule ExVCR.Adapter.Httpc.Converter do
     response
   end
 
-  defp convert_string_to_char_list(elem) do
+  defp convert_string_to_charlist(elem) do
     if is_binary(elem) do
       to_charlist(elem)
     else

--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -59,7 +59,7 @@ defmodule ExVCR.Adapter.IBrowse do
     else
       status_code = case response.status_code do
         integer when is_integer(integer) ->
-          Integer.to_char_list(integer)
+          Integer.to_charlist(integer)
         char_list when is_list(char_list) ->
           char_list
       end

--- a/lib/exvcr/adapter/ibrowse/converter.ex
+++ b/lib/exvcr/adapter/ibrowse/converter.ex
@@ -11,7 +11,7 @@ defmodule ExVCR.Adapter.IBrowse.Converter do
 
     response =
       if response.status_code do
-        %{response | status_code: Integer.to_char_list(response.status_code)}
+        %{response | status_code: Integer.to_charlist(response.status_code)}
       else
         response
       end

--- a/lib/exvcr/adapter/ibrowse/converter.ex
+++ b/lib/exvcr/adapter/ibrowse/converter.ex
@@ -28,7 +28,7 @@ defmodule ExVCR.Adapter.IBrowse.Converter do
       if is_map(response.headers) do
         headers = response.headers
                   |> Map.to_list
-                  |> Enum.map(fn({k,v}) -> {to_char_list(k), to_char_list(v)} end)
+                  |> Enum.map(fn({k,v}) -> {to_charlist(k), to_charlist(v)} end)
         %{response | headers: headers}
       else
         response


### PR DESCRIPTION
[`Kernel.to_char_list` and `Integer.to_char_list` have been deprecated](https://github.com/elixir-lang/elixir/blob/0b0ab9f8ef420ea07878e3156386ddad10bb3ea8/lib/elixir/src/elixir_dispatch.erl#L382-L385) in favor of the versions with one less underscore:

See elixir-lang/elixir#4909.

This change will silence the warnings when compiling the package.