### PR TITLE
Support binary responses

### DIFF
--- a/fixture/vcr_cassettes/hackney_get_gzipped.json
+++ b/fixture/vcr_cassettes/hackney_get_gzipped.json
@@ -12,7 +12,22 @@
     },
     "response": {
       "binary": true,
-      "body": "g20AAAJeH4sIADuBBVIAA41UQa/TMAy+71eYcgFpXfeAB1PXViBA4gIc4MIxa9zVWpOUJO02offfcdu9ruXtQCu1jh1//mzHSZ5Jk/tzjVB6VWWL5PGHQmYL4Cfx5CvMPp+EqiuET0YJ0kk0aBfDFoVeQF4K69CnQeOLcBNAlE2Mpfd1iL8batPgo9EetQ+7sAHkwyoNPJ581IXfjlC3kLRQmAYt4bE21k/8jyR9mUpsKcewXyyBNHkSVehyUWF6d4Vy/szJdAwugXPngsG2M/IMf3qxX4r8sLem0TLMTWVsDM+LNb+vtuMWJeyedAzrq6oWUpLez3QFMw0Loag6xxB8r1HDD6FdsITgC1YtesoFfMMGWTMqlvDBcgZLcLw1dGipuCL2wkP/ldROSPfpx/B2va5PT3neowLReHOD7v3M4VbuxST+zliJNrRCUuNiuEO1nVAScUX6sOR/S448ygnBR7jXmzebzQSx60UoMTdWeDLMVRuNU9D3CiUJeKHEKbxk+a7L8uW0ZfMO/k8mD6M0L+SkmPOKzfp+w/ZPadZz61jvsWRXEsM3ifojmnXyIomGeVwkXWo8nkzycpDLuyejyarBVmc/S3Igez2whM6LXUWu5F54AzuExrFYGAtUVY3zXdVbBBwQHc8Pe+eN4gFzK/hlGs753DmBZ+Th4F3Q9dXrSL40jYfaEiPnhktBuu8n8Fq4A6feB63RKnKODaskqkfWCd8XFos06G6NOIqOx+OKhBYrY/fREM9Fl2hB9tVY5PCMp/oYqxWDiawHTKK+Ukl0qVs0XG9/AQiVqov2BAAA"
+      "body": "g20AAAJeH4sIADuBBVIAA41UQa/TMAy+71eYcgFpXfeAB1PXViBA4gIc4MIxa9zVWpOUJO02offfcdu9ruXtQCu1jh1//mzHSZ5Jk/tzjVB6VWWL5PGHQmYL4Cfx5CvMPp+EqiuET0YJ0kk0aBfDFoVeQF4K69CnQeOLcBNAlE2Mpfd1iL8batPgo9EetQ+7sAHkwyoNPJ581IXfjlC3kLRQmAYt4bE21k/8jyR9mUpsKcewXyyBNHkSVehyUWF6d4Vy/szJdAwugXPngsG2M/IMf3qxX4r8sLem0TLMTWVsDM+LNb+vtuMWJeyedAzrq6oWUpLez3QFMw0Loag6xxB8r1HDD6FdsITgC1YtesoFfMMGWTMqlvDBcgZLcLw1dGipuCL2wkP/ldROSPfpx/B2va5PT3neowLReHOD7v3M4VbuxST+zliJNrRCUuNiuEO1nVAScUX6sOR/S448ygnBR7jXmzebzQSx60UoMTdWeDLMVRuNU9D3CiUJeKHEKbxk+a7L8uW0ZfMO/k8mD6M0L+SkmPOKzfp+w/ZPadZz61jvsWRXEsM3ifojmnXyIomGeVwkXWo8nkzycpDLuyejyarBVmc/S3Igez2whM6LXUWu5F54AzuExrFYGAtUVY3zXdVbBBwQHc8Pe+eN4gFzK/hlGs753DmBZ+Th4F3Q9dXrSL40jYfaEiPnhktBuu8n8Fq4A6feB63RKnKODaskqkfWCd8XFos06G6NOIqOx+OKhBYrY/fREM9Fl2hB9tVY5PCMp/oYqxWDiawHTKK+Ukl0qVs0XG9/AQiVqov2BAAA",
+      "headers": {
+        "Content-Encoding": "gzip",
+        "Cache-Control": "max-age=604800",
+        "Content-Type": "text/html",
+        "Date": "Wed, 13 Sep 2017 08:22:45 GMT",
+        "Etag": "\"359670651+gzip\"",
+        "Expires": "Wed, 20 Sep 2017 08:22:45 GMT",
+        "Last-Modified": "Fri, 09 Aug 2013 23:54:35 GMT",
+        "Server": "ECS (lga/1378)",
+        "Vary": "Accept-Encoding",
+        "X-Cache": "HIT",
+        "Content-Length": "606"
+      },
+      "status_code": 200,
+      "type": "ok"
     }
   }
 ]

--- a/fixture/vcr_cassettes/hackney_get_gzipped.json
+++ b/fixture/vcr_cassettes/hackney_get_gzipped.json
@@ -11,23 +11,8 @@
       "url": "http://www.example.com"
     },
     "response": {
-      "body": "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color: #fff;\n        }\n        div {\n            width: auto;\n            margin: 0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is established to be used for illustrative examples in documents. You may use this\n    domain in examples without prior coordination or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More information...</a></p>\n</div>\n</body>\n</html>\n",
-      "headers": {
-        "Content-Encoding": "gzip",
-        "Cache-Control": "max-age=604800",
-        "Content-Type": "text/html",
-        "Date": "Mon, 14 Mar 2016 20:53:24 GMT",
-        "Etag": "\"359670651+gzip\"",
-        "Expires": "Mon, 21 Mar 2016 20:53:24 GMT",
-        "Last-Modified": "Fri, 09 Aug 2013 23:54:35 GMT",
-        "Server": "ECS (rhv/818F)",
-        "Vary": "Accept-Encoding",
-        "X-Cache": "HIT",
-        "x-ec-custom-error": "1",
-        "Content-Length": "606"
-      },
-      "status_code": 200,
-      "type": "ok"
+      "binary": true,
+      "body": "g20AAAJeH4sIADuBBVIAA41UQa/TMAy+71eYcgFpXfeAB1PXViBA4gIc4MIxa9zVWpOUJO02offfcdu9ruXtQCu1jh1//mzHSZ5Jk/tzjVB6VWWL5PGHQmYL4Cfx5CvMPp+EqiuET0YJ0kk0aBfDFoVeQF4K69CnQeOLcBNAlE2Mpfd1iL8batPgo9EetQ+7sAHkwyoNPJ581IXfjlC3kLRQmAYt4bE21k/8jyR9mUpsKcewXyyBNHkSVehyUWF6d4Vy/szJdAwugXPngsG2M/IMf3qxX4r8sLem0TLMTWVsDM+LNb+vtuMWJeyedAzrq6oWUpLez3QFMw0Loag6xxB8r1HDD6FdsITgC1YtesoFfMMGWTMqlvDBcgZLcLw1dGipuCL2wkP/ldROSPfpx/B2va5PT3neowLReHOD7v3M4VbuxST+zliJNrRCUuNiuEO1nVAScUX6sOR/S448ygnBR7jXmzebzQSx60UoMTdWeDLMVRuNU9D3CiUJeKHEKbxk+a7L8uW0ZfMO/k8mD6M0L+SkmPOKzfp+w/ZPadZz61jvsWRXEsM3ifojmnXyIomGeVwkXWo8nkzycpDLuyejyarBVmc/S3Igez2whM6LXUWu5F54AzuExrFYGAtUVY3zXdVbBBwQHc8Pe+eN4gFzK/hlGs753DmBZ+Th4F3Q9dXrSL40jYfaEiPnhktBuu8n8Fq4A6feB63RKnKODaskqkfWCd8XFos06G6NOIqOx+OKhBYrY/fREM9Fl2hB9tVY5PCMp/oYqxWDiawHTKK+Ukl0qVs0XG9/AQiVqov2BAAA"
     }
   }
 ]

--- a/lib/exvcr/json.ex
+++ b/lib/exvcr/json.ex
@@ -54,7 +54,7 @@ defmodule ExVCR.JSON do
   end
 
   defp load_binary_data(%{"body" => body, "binary" => true} = recording) do
-    body
+    body = body
     |> Base.decode64!()
     |> :erlang.binary_to_term()
     %{ recording | "body" => body }

--- a/lib/exvcr/json.ex
+++ b/lib/exvcr/json.ex
@@ -46,18 +46,17 @@ defmodule ExVCR.JSON do
   Reads and parse the json file located at the specified file_name.
   """
   def read_json_file(file_name) do
-    file = File.read!(file_name)
-    recordings = JSX.decode!(file)
-
-    recordings
+    file_name
+    |> File.read!()
+    |> JSX.decode!()
     |> Enum.map(&load_binary_data/1)
   end
 
-  defp load_binary_data(%{"body" => body, "binary" => true} = recording) do
+  defp load_binary_data(%{"response" => %{"body" => body, "binary" => true} = response} = recording) do
     body = body
     |> Base.decode64!()
     |> :erlang.binary_to_term()
-    %{ recording | "body" => body }
+    %{ recording | "response" => %{ response | "body" => body } }
   end
 
   defp load_binary_data(recording), do: recording

--- a/lib/exvcr/json.ex
+++ b/lib/exvcr/json.ex
@@ -17,16 +17,16 @@ defmodule ExVCR.JSON do
     File.write!(file_name, json)
   end
 
-  defp encode_binary_data(recording = %{request: _, response: %ExVCR.Response{body: nil}}), do: recording
+  defp encode_binary_data(%{request: _, response: %ExVCR.Response{body: nil}} = recording), do: recording
 
-  defp encode_binary_data(recording = %{response: response}) do
+  defp encode_binary_data(%{response: response} = recording) do
     case String.valid?(response.body) do
       true -> recording
       false ->
         body = response.body
         |> :erlang.term_to_binary()
         |> Base.encode64()
-        %{ recording | response: %{ body: body, binary: true } }
+        %{ recording | response: %{ response | body: body, binary: true } }
     end
   end
 

--- a/lib/exvcr/records.ex
+++ b/lib/exvcr/records.ex
@@ -7,7 +7,7 @@ defmodule ExVCR.Request do
 end
 
 defmodule ExVCR.Response do
-  defstruct type: "ok", status_code: nil, headers: [], body: nil
+  defstruct type: "ok", status_code: nil, headers: [], body: nil, binary: false
 end
 
 defmodule ExVCR.Checker.Results do

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule ExVCR.Mixfile do
   # { :foobar, "~> 0.1", git: "https://github.com/elixir-lang/foobar.git" }
   def deps do
     [
-      {:meck, "~> 0.8.3"},
+      {:meck, "~> 0.8.8"},
       {:exactor, "~> 2.2"},
       {:exjsx, "~> 4.0"},
       {:ibrowse, "~> 4.4", optional: true},

--- a/mix.lock
+++ b/mix.lock
@@ -13,7 +13,7 @@
   "ibrowse": {:hex, :ibrowse, "4.4.0", "2d923325efe0d2cb09b9c6a047b2835a5eda69d8a47ed6ff8bc03628b764e991", [:rebar3], []},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, optional: false]}]},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [], []},
+  "meck": {:hex, :meck, "0.8.8", "eeb3efe811d4346e1a7f65b2738abc2ad73cbe1a2c91b5dd909bac2ea0414fa6", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [], []},


### PR DESCRIPTION
Hi!

I ran into some issues when using VCR to record interactions with a MessagePack based backend since JSON can only encode binary data.

I rewrote the saving and loading parts to base64-encode the data, if it is deemed to be binary (i.e isn't a valid string).

Since the gzip handling is a subset of binary data, I got rid of the special casing for gzipped data as well. The downside of this is that old cassettes containing gzipped data will need to be re-recorded (we could of course keep the special casing of gzipped data) and gzipped endpoints won't be easily inspectable via the json cassettes.

I think that's a fair tradeoff in order to get the recordings as close as possible to the actual API.