### PR TITLE
Allow ExVCR.Config.filter_request_headers to receive a list of headers

### DIFF
--- a/lib/exvcr/config.ex
+++ b/lib/exvcr/config.ex
@@ -40,6 +40,14 @@ defmodule ExVCR.Config do
   end
 
   @doc """
+  Replace the specified list of request headers with placeholder.
+  It can be used to remove sensitive data from the casette file.
+  """
+  def filter_request_headers(headers) when is_list(headers) do
+    headers |> Enum.each(& Setting.append(:filter_request_headers, &1))
+  end
+
+  @doc """
   Replace the specified request header with placeholder.
   It can be used to remove sensitive data from the casette file.
   """

--- a/test/recorder_ibrowse_test.exs
+++ b/test/recorder_ibrowse_test.exs
@@ -83,6 +83,23 @@ defmodule ExVCR.RecorderIBrowseTest do
     ExVCR.Config.filter_request_headers(nil)
   end
 
+  test "replace sensitive list of data in request header" do
+    ExVCR.Config.filter_request_headers(["X-My-Secret-Token", "X-My-Other-Sensitive-Token"])
+    use_cassette "sensitive_list_of_data_in_request_header" do
+      headers = ["X-My-Secret-Token": "my-secret-token", "X-My-Other-Sensitive-Token": "other-secret-token"]
+      assert HTTPotion.get(@url_with_query, [headers: headers]).body =~ ~r/test_response/
+    end
+
+    # The recorded cassette should contain replaced data.
+    cassette = File.read!("#{@dummy_cassette_dir}/sensitive_list_of_data_in_request_header.json")
+    assert cassette =~ "\"X-My-Secret-Token\": \"***\""
+    assert cassette =~ "\"X-My-Other-Sensitive-Token\": \"***\""
+    refute cassette =~ "\"X-My-Secret-Token\": \"my-secret-token\""
+    refute cassette =~ "\"X-My-Other-Sensitive-Token\": \"other-secret-token\""
+
+    ExVCR.Config.filter_request_headers(nil)
+  end
+
   test "replace sensitive data in request options" do
     ExVCR.Config.filter_request_options("basic_auth")
     use_cassette "sensitive_data_in_request_options" do


### PR DESCRIPTION
Currently, it is not possible to do something like, `ExVCR.Config.filter_request_headers(["header_one", "header_two"]`. 

This PR makes this possible.

Since `ExVCR.Config.filter_request_headers` is a plural term (`headers`) and it is possible to give a list of values when defining this config on `config.exs` as `filter_request_headers: []`, it seems that it is really non-intuitive the fact of giving a list of values to the function, it does not work (also no errors happen).