### PR TITLE
Add a config key to allow a global ets settings table

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,5 +9,6 @@ config :exvcr, [
   filter_url_params: false,
   filter_request_headers: [],
   response_headers_blacklist: [],
-  ignore_localhost: false
+  ignore_localhost: false,
+  enable_global_settings: false
 ]

--- a/lib/exvcr/setting.ex
+++ b/lib/exvcr/setting.ex
@@ -25,6 +25,10 @@ defmodule ExVCR.Setting do
   end
 
   defp table do
-    "exvcr_setting#{inspect self()}" |> String.to_atom
+    if Application.get_env(:exvcr, :enable_global_settings) do
+      :exvcr_setting
+    else
+      :"exvcr_setting#{inspect self()}"
+    end
   end
 end

--- a/test/enable_global_settings_test.exs
+++ b/test/enable_global_settings_test.exs
@@ -1,0 +1,29 @@
+defmodule ExVCR.EnableGlobalSettingsTest do
+  use ExVCR.Mock
+  use ExUnit.Case, async: false
+
+  test "settings are normally per-process" do
+    original_value = ExVCR.Setting.get(:custom_library_dir)
+
+    ExVCR.Setting.set(:custom_library_dir, "global_setting_test")
+
+    setting_from_task = Task.async(fn -> ExVCR.Setting.get(:custom_library_dir) end)
+
+    assert Task.await(setting_from_task) == original_value
+    assert ExVCR.Setting.get(:custom_library_dir) == "global_setting_test"
+  end
+
+  test "settings are shared globally among processes" do
+    original_setting = Application.get_env(:exvcr, :enable_global_settings)
+
+    Application.put_env(:exvcr, :enable_global_settings, true)
+
+    ExVCR.Setting.set(:custom_library_dir, "global_setting_test")
+
+    setting_from_task = Task.async(fn -> ExVCR.Setting.get(:custom_library_dir) end)
+
+    assert Task.await(setting_from_task) == "global_setting_test"
+
+    Application.put_env(:exvcr, :enable_global_settings, original_setting)
+  end
+end


### PR DESCRIPTION
We need to mock the responses of HTTPoison calls that get triggered through a Task, and prior versions of ExVCR would not conflict with it because there was a common global ETS table name. While fixing the async behaviour, ExVCR also made it impossible to have any custom settings apply to tasks spawned outside of test code.

It broke `setup_all` and that behaviour is documented and is fixable, but I cannot think of a fix for this particular scenario other than going back to a global name for when we want this behaviour. This PR adds back using a global name as an option.

If you think that a better way to do this exists, please let me know.