### PR TITLE
Fix ignore localhost when using headers

### DIFF
--- a/fixture/vcr_cassettes/record_example_localhost_on.json
+++ b/fixture/vcr_cassettes/record_example_localhost_on.json
@@ -1,0 +1,30 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://www.example.com/"
+    },
+    "response": {
+      "binary": false,
+      "body": "<!doctype html>\n<html>\n<head>\n    <title>Example Domain</title>\n\n    <meta charset=\"utf-8\" />\n    <meta http-equiv=\"Content-type\" content=\"text/html; charset=utf-8\" />\n    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />\n    <style type=\"text/css\">\n    body {\n        background-color: #f0f0f2;\n        margin: 0;\n        padding: 0;\n        font-family: \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n        \n    }\n    div {\n        width: 600px;\n        margin: 5em auto;\n        padding: 50px;\n        background-color: #fff;\n        border-radius: 1em;\n    }\n    a:link, a:visited {\n        color: #38488f;\n        text-decoration: none;\n    }\n    @media (max-width: 700px) {\n        body {\n            background-color: #fff;\n        }\n        div {\n            width: auto;\n            margin: 0 auto;\n            border-radius: 0;\n            padding: 1em;\n        }\n    }\n    </style>    \n</head>\n\n<body>\n<div>\n    <h1>Example Domain</h1>\n    <p>This domain is established to be used for illustrative examples in documents. You may use this\n    domain in examples without prior coordination or asking for permission.</p>\n    <p><a href=\"http://www.iana.org/domains/example\">More information...</a></p>\n</div>\n</body>\n</html>\n",
+      "headers": {
+        "Cache-Control": "max-age=604800",
+        "Content-Type": "text/html",
+        "Date": "Thu, 26 Jul 2018 21:42:03 GMT",
+        "Etag": "\"1541025663+gzip+ident\"",
+        "Expires": "Thu, 02 Aug 2018 21:42:03 GMT",
+        "Last-Modified": "Fri, 09 Aug 2013 23:54:35 GMT",
+        "Server": "ECS (sjc/4E8D)",
+        "Vary": "Accept-Encoding",
+        "X-Cache": "HIT",
+        "Content-Length": "1270"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -152,7 +152,9 @@ defmodule ExVCR.Handler do
   defp ignore_request?(request, recorder) do
     ignore_localhost = ExVCR.Recorder.options(recorder)[:ignore_localhost] || ExVCR.Setting.get(:ignore_localhost)
     if ignore_localhost do
-      Enum.any?(request, &(String.starts_with?("#{&1}", "http://localhost:")))
+      adapter = ExVCR.Recorder.options(recorder)[:adapter]
+      url = adapter.generate_keys_for_request(request)[:url]
+      String.starts_with?(to_string(url), "http://localhost:")
     else
       false
     end

--- a/test/ignore_localhost_test.exs
+++ b/test/ignore_localhost_test.exs
@@ -22,6 +22,14 @@ defmodule ExVCR.IgnoreLocalhostTest do
     end
   end
 
+  test "it records non-localhost requests when the config has been set and headers are sent" do
+    use_cassette "record_example_localhost_on", ignore_localhost: true do
+      response = HTTPotion.get("http://www.example.com/", [headers: ["Content-Type": "text/html"]])
+      assert response.body =~ ~r/Example Domain/
+      assert response.status_code == 200
+    end
+  end
+
   test "it records localhost requests when the config has not been set" do
     use_cassette "ignore_localhost_unset" do
       HttpServer.start(path: "/server", port: @port, response: "test_response_before")


### PR DESCRIPTION
Fixes the ignore_localhost option when recording requests that send
headers. This was raising an ArgumentError because every element of the
request was being enumerated and checked as a String (including
non-string-like maps, which is how headers are represented).

This changes the checking of the url to get the url out of the request
via the corresponding adapter.