### PR TITLE
Filter request headers before attempting to match with cassette

### DIFF
--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -96,10 +96,22 @@ defmodule ExVCR.Handler do
 
   defp match_by_headers(response, keys, options) do
     if has_match_requests_on(:headers, options) do
-      response[:request].headers
-      |> Enum.to_list
-      |> Util.stringify_keys
-      |> Keyword.equal?(keys[:headers])
+      request_headers =
+        keys[:headers]
+        |> Util.stringify_keys()
+        |> Enum.map(fn {key, value} ->
+          replaced_value = ExVCR.Filter.filter_sensitive_data(value)
+          replaced_value = ExVCR.Filter.filter_request_header(key, replaced_value)
+
+          {key, replaced_value}
+        end)
+
+      response_headers =
+        response[:request].headers
+        |> Enum.to_list()
+        |> Util.stringify_keys()
+
+      Keyword.equal?(request_headers, response_headers)
     else
       true
     end

--- a/test/recorder_hackney_test.exs
+++ b/test/recorder_hackney_test.exs
@@ -86,6 +86,27 @@ defmodule ExVCR.RecorderHackneyTest do
     ExVCR.Config.filter_request_headers(nil)
   end
 
+  test "replace sensitive data in matching request header" do
+    ExVCR.Config.filter_sensitive_data("Basic [a-z]+", "Basic ***")
+
+    use_cassette "sensitive_data_matches_in_request_headers", match_requests_on: [:headers] do
+      body = HTTPoison.get!(@url, [{"Authorization", "Basic credentials"}]).body
+      assert body == "test_response"
+    end
+
+    # The recorded cassette should contain replaced data.
+    cassette = File.read!("#{@dummy_cassette_dir}/sensitive_data_matches_in_request_headers.json")
+    assert cassette =~ "\"Authorization\": \"Basic ***\""
+
+    # Attempt another request should match on filtered header
+    use_cassette "sensitive_data_matches_in_request_headers", match_requests_on: [:headers] do
+      body = HTTPoison.get!(@url, [{"Authorization", "Basic credentials"}]).body
+      assert body == "test_response"
+    end
+
+    ExVCR.Config.filter_sensitive_data(nil)
+  end
+
   test "replace sensitive data in request options" do
     ExVCR.Config.filter_request_options("basic_auth")
     use_cassette "sensitive_data_in_request_options" do


### PR DESCRIPTION
When you configure ExVCR with `filter_sensitive_data` and/or `filter_request_headers` any sensitive information is removed from request headers when stored on disk as a cassette. If you attempt to use the stored cassette, and specify `match_requests_on: [:headers]`, it won't match because the header values have been filtered and won't be the same as the unfiltered raw request headers.

This pull request applies sensitive data filtering to the request headers before comparing with recorded cassette for equality. I've included tests for each of the three adapters to verify the change.