### PR TITLE
Enforce match on :hackney.request/1, /2, /3 and /4

### DIFF
--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -28,19 +28,25 @@ defmodule ExVCR.Adapter.Hackney do
   Returns list of the mock target methods with function name and callback.
   """
   def target_methods(recorder) do
-    [ {:request, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4,&5])},
-      {:body,    &handle_body_request(recorder, [&1])},
-      {:body,    &handle_body_request(recorder, [&1,&2])} ]
+    [
+      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3, &4, &5])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3, &4])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1, &2])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1])},
+      {:body, &handle_body_request(recorder, [&1])},
+      {:body, &handle_body_request(recorder, [&1, &2])}
+    ]
   end
 
   @doc """
   Generate key for searching response.
   """
   def generate_keys_for_request(request) do
-    url    = Enum.fetch!(request, 1)
-    method = Enum.fetch!(request, 0)
+    url          = Enum.fetch!(request, 1)
+    method       = Enum.fetch!(request, 0)
     request_body = Enum.fetch(request, 3) |> parse_request_body
-    headers = Enum.fetch!(request, 2) |> Util.stringify_keys
+    headers      = Enum.at(request, 2, []) |> Util.stringify_keys()
 
     [url: url, method: method, request_body: request_body, headers: headers]
   end

--- a/lib/exvcr/adapter/hackney/converter.ex
+++ b/lib/exvcr/adapter/hackney/converter.ex
@@ -20,13 +20,19 @@ defmodule ExVCR.Adapter.Hackney.Converter do
     response
   end
 
-  defp request_to_string([method, url, headers, body, options]) do
+  defp request_to_string(request) do
+    method  = Enum.fetch!(request, 0) |> to_string()
+    url     = Enum.fetch!(request, 1) |> parse_url()
+    headers = Enum.at(request, 2, []) |> parse_headers()
+    body    = Enum.at(request, 3, "") |> parse_request_body()
+    options = Enum.at(request, 4, []) |> sanitize_options() |> parse_options()
+
     %ExVCR.Request{
-      url: parse_url(url),
-      headers: parse_headers(headers),
-      method: to_string(method),
-      body: parse_request_body(body),
-      options: parse_options(sanitize_options(options))
+      url: url,
+      headers: headers,
+      method: method,
+      body: body,
+      options: options
     }
   end
 


### PR DESCRIPTION
Fixes #144.

When calling either of

```elixir
:hackney.head(url)
:hackney.request(:head, url)
```

no request is matched in the `target_methods/1` call, due to the fact
that in Hackney `head` function calls in hackney don't call the `body`
function.

As a result, when making `:hackney.head/1` calls, the request hits
the destination instead of being captured.

I'm not sure if this is the best option to do so, but adding defaults seemed a sensible option.