### PR TITLE
Add support for custom matcher functions

### DIFF
--- a/fixture/vcr_cassettes/user_defined_matchers_matching.json
+++ b/fixture/vcr_cassettes/user_defined_matchers_matching.json
@@ -1,0 +1,26 @@
+[
+  {
+    "request": {
+      "body": "p=3",
+      "headers": {
+        "User-Agent": "My App",
+        "X-Special-Header": "Value One"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34006/server"
+    },
+    "response": {
+      "binary": false,
+      "body": "test_response_before",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Fri, 13 Sep 2019 13:02:19 GMT",
+        "content-length": "20"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/user_defined_matchers_not_matching.json
+++ b/fixture/vcr_cassettes/user_defined_matchers_not_matching.json
@@ -1,0 +1,50 @@
+[
+  {
+    "request": {
+      "body": "p=3",
+      "headers": {
+        "User-Agent": "My App",
+        "X-Special-Header": "Value One"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34006/server"
+    },
+    "response": {
+      "binary": false,
+      "body": "test_response_before",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Fri, 13 Sep 2019 13:02:18 GMT",
+        "content-length": "20"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "p=4",
+      "headers": {
+        "User-Agent": "Other App",
+        "X-Special-Header": "Value Two"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34006/server"
+    },
+    "response": {
+      "binary": false,
+      "body": "test_response_after",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Fri, 13 Sep 2019 13:02:18 GMT",
+        "content-length": "19"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -73,6 +73,14 @@ defmodule ExVCR.Handler do
       and match_by_method(response, keys)
       and match_by_request_body(response, keys, recorder_options)
       and match_by_headers(response, keys, recorder_options)
+      and match_by_custom_matchers(response, keys, recorder_options)
+  end
+
+  defp match_by_custom_matchers(response, keys, recorder_options) do
+    custom_matchers = recorder_options[:custom_matchers] || []
+    Enum.reduce_while(custom_matchers, true, fn matcher, _acc ->
+      if matcher.(response, keys, recorder_options), do: {:cont, true}, else: {:halt, false}
+    end)
   end
 
   defp match_by_url(response, keys, recorder_options) do


### PR DESCRIPTION
Hello!

This changeset adds the ability to specify any function (or set of functions)
that provide custom matching behaviour by using a new `custom_matchers` option.

As demonstrated in the example provided in the README.md and tests, this should allow to resolve issues like #134 where more specific matching logic is for whatever reason required.

This also opens the possibility of a bigger refactor, where even the "default" matchers (url, method, headers, body etc) are simply functions that are applied in the same way, and users can decide which ones to use or not (removing the need for the `match_requests_on` option).