### PR TITLE
Fix warnings from OptionParser in exvcr mix tasks

### DIFF
--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -76,7 +76,7 @@ defmodule Mix.Tasks.Vcr do
 
     @doc "Entry point for [mix vcr.show] task."
     def run(args) do
-      {_options, files, _} = OptionParser.parse(args, aliases: [])
+      {_options, files, _} = OptionParser.parse(args, aliases: [], switches: [])
       ExVCR.Task.Show.run(files)
     end
   end

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Vcr do
 
     @doc "Entry point for [mix vcr.check] task."
     def run(args) do
-      {options, _files, _} = OptionParser.parse(args, aliases: [d: :dir, c: :custom])
+      {options, _files, _} = OptionParser.parse(args, aliases: [d: :dir, c: :custom], switches: [dir: :string, custom: :string])
       dirs = ExVCR.Task.Util.parse_basic_options(options)
       ExVCR.Checker.start(%ExVCR.Checker.Results{dirs: dirs})
 

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -14,7 +14,7 @@ defmodule Mix.Tasks.Vcr do
 
   @doc "Entry point for [mix vcr] task"
   def run(args) do
-    {options, _, _} = OptionParser.parse(args, aliases: [d: :dir, c: :custom, h: :help])
+    {options, _, _} = OptionParser.parse(args, aliases: [d: :dir, c: :custom, h: :help], switches: [dir: :string, custom: :string, help: :boolean])
     if options[:help] do
       ExVCR.Task.Util.print_help_message
     else


### PR DESCRIPTION
I'm new to Elixir but fluent in Ruby/VCR. I just [implemented exvcr on a small Elixir project](https://github.com/javierjulio/binlist-elixir/) where I ran into this and thought I could take a shot at resolving it.

When running either the entry task `mix vcr` or the `mix vcr.check` task, it shows the same warning message below, but will just have a different stacktrace:

```
> mix vcr
warning: not passing the :switches or :strict option to OptionParser is deprecated
  (elixir) lib/option_parser.ex:607: OptionParser.build_config/1
  (elixir) lib/option_parser.ex:231: OptionParser.parse/2
  lib/mix/tasks.ex:17: Mix.Tasks.Vcr.run/1
  (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
  (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```

These warnings occurred on Elixir v1.9 but I'm not sure what other versions they may or may not occur on. From [the documentation](https://hexdocs.pm/elixir/OptionParser.html#parse/2) and other usage here, I thought the `switches` key was the preferred approach but I may be wrong. Please correct me and I will be happy to update.

When setting up exvcr on my project, it worked on the first try. Thanks so much! ❤️