### PR TITLE
Add strict_mode option to ensure HTTP calls DO NOT get made

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -10,5 +10,6 @@ config :exvcr, [
   filter_request_headers: [],
   response_headers_blacklist: [],
   ignore_localhost: false,
-  enable_global_settings: false
+  enable_global_settings: false,
+  strict_mode: false
 ]

--- a/lib/exvcr/config.ex
+++ b/lib/exvcr/config.ex
@@ -84,4 +84,11 @@ defmodule ExVCR.Config do
   def ignore_localhost(value) do
     Setting.set(:ignore_localhost, value)
   end
+
+  @doc """
+  Throw error if there is no matching cassette for an HTTP request
+  """
+  def strict_mode(value) do
+    Setting.set(:strict_mode, value)
+  end
 end

--- a/lib/exvcr/config_loader.ex
+++ b/lib/exvcr/config_loader.ex
@@ -56,5 +56,9 @@ defmodule ExVCR.ConfigLoader do
     if env[:ignore_localhost] != nil do
       Config.ignore_localhost(env[:ignore_localhost])
     end
+
+    if env[:strict_mode] != nil do
+      Config.strict_mode(env[:strict_mode])
+    end
   end
 end

--- a/test/strict_mode_test.exs
+++ b/test/strict_mode_test.exs
@@ -1,0 +1,55 @@
+defmodule ExVCR.StrictModeTest do
+  use ExVCR.Mock
+  use ExUnit.Case, async: false
+
+  @dummy_cassette_dir "tmp/vcr_tmp/vcr_cassettes_strict_mode"
+  @port 34007
+  @url "http://localhost:#{@port}/server"
+  @http_server_opts [path: "/server", port: @port, response: "test_response"]
+
+  setup_all do
+    File.rm_rf(@dummy_cassette_dir)
+
+    on_exit fn ->
+      File.rm_rf(@dummy_cassette_dir)
+      HttpServer.stop(@port)
+      :ok
+    end
+
+    HTTPotion.start
+    HttpServer.start(@http_server_opts)
+    :ok
+  end
+
+  setup do
+    ExVCR.Config.cassette_library_dir(@dummy_cassette_dir)
+  end
+
+  test "it makes HTTP calls if not set" do
+    use_cassette "strict_mode_off", strict_mode: false do
+      assert HTTPotion.get(@url, []).body =~ ~r/test_response/
+    end
+  end
+
+  test "it throws an error when set and no cassette recorded" do
+    use_cassette "strict_mode_on", strict_mode: true do
+      try do
+       HTTPotion.get(@url, []).body =~ ~r/test_response/
+       assert(false, "Shouldn't get here")
+      catch
+        "A matching cassette was not found" <> _ -> assert(true)
+        _ -> assert(false, "Encountered unexpected `throw`")
+      end
+    end
+  end
+
+  test "it uses a cassette if it exists" do
+    use_cassette "strict_mode_cassette", strict_mode: false do
+      assert HTTPotion.get(@url, []).body =~ ~r/test_response/
+    end
+
+    use_cassette "strict_mode_cassette", strict_mode: true do
+      assert HTTPotion.get(@url, []).body =~ ~r/test_response/
+    end
+  end
+end


### PR DESCRIPTION
This change adds a new option called strict_mode. When turned on, if a matching cassette cannot be found, an error will be thrown.

## Problem
- In a large codebase (e.g. has hundreds of tests) it is hard to validate if every HTTP call has a cassette defined for it. With strict_mode turned, an HTTP call without a cassette will cause a test to fail, making it easy to identify which calls are missing cassettes.
- Some HTTP calls are destructive or mutate data and should never be called while running tests. Strict_mode enables ExVCR to be used for these HTTP calls without the risk of accidentally making an actual HTTP call

## Why use `throw` not `raise`?
In practice there's a reasonable amount of code out in the wild that will handle any exception raised in order to give a reasonable default error message to an end user/consumer. For example, a controller might do something like:

```
  def controller_handle_request(conn, params) do
    make_http_call_that_may_raise()
  rescue
    _ -> return_nice_error()
  end
```

Unfortunately if this controller is mocked by ExVCR an exception raised by `strict_mode` would also get handled by this controller :(

`throw`'s sit outside of exceptions, and won't get clobbered by any kind of `rescue`, thus surfacing `strict_mode` errors to developers in this scenario.