### PR TITLE
Use global mock in adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It's inspired by Ruby's VCR (https://github.com/vcr/vcr), and trying to provide 
 
 ### Notes
 - ExVCR.Config functions must be called from setup or test. Calls outside of test process, such as in setup_all will not work.
+- ExVCR implements global mock, which means that all HTTP client calls outside of `use_cassette` go through `meck.passthough/1`.
 
 ### Install
 Add `:exvcr` to `deps` section of `mix.exs`.

--- a/fixture/vcr_cassettes/hackney_get_localhost.json
+++ b/fixture/vcr_cassettes/hackney_get_localhost.json
@@ -1,0 +1,25 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": {
+        "with_body": "true"
+      },
+      "request_body": "",
+      "url": "http://localhost:34009/server"
+    },
+    "response": {
+      "binary": false,
+      "body": "test_response",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 29 Sep 2020 11:50:14 GMT",
+        "content-length": "13"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/httpc_get_localhost.json
+++ b/fixture/vcr_cassettes/httpc_get_localhost.json
@@ -1,0 +1,30 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": {
+        "httpc_options": [],
+        "http_options": []
+      },
+      "request_body": "",
+      "url": "http://localhost:34010/server"
+    },
+    "response": {
+      "binary": false,
+      "body": "test_response",
+      "headers": {
+        "date": "Tue, 29 Sep 2020 11:52:26 GMT",
+        "server": "Cowboy",
+        "content-length": "13"
+      },
+      "status_code": [
+        "HTTP/1.1",
+        200,
+        "OK"
+      ],
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/ibrowse_get_localhost.json
+++ b/fixture/vcr_cassettes/ibrowse_get_localhost.json
@@ -1,0 +1,23 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:34011/server"
+    },
+    "response": {
+      "binary": false,
+      "body": "test_response",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 29 Sep 2020 11:56:58 GMT",
+        "content-length": "13"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/exvcr/actor.ex
+++ b/lib/exvcr/actor.ex
@@ -50,7 +50,7 @@ defmodule ExVCR.Actor do
 
   defmodule CurrentRecorder do
     @moduledoc """
-    Stores current recorder to be able to fetch it inside of mocked versio of adapter.
+    Stores current recorder to be able to fetch it inside of the mocked version of the adapter.
     """
 
     use ExActor.GenServer, export: __MODULE__

--- a/lib/exvcr/actor.ex
+++ b/lib/exvcr/actor.ex
@@ -47,4 +47,17 @@ defmodule ExVCR.Actor do
     defcast set(x), do: new_state(x)
     defcall get, state: state, do: reply(state)
   end
+
+  defmodule CurrentRecorder do
+    @moduledoc """
+    Stores current recorder to be able to fetch it inside of mocked versio of adapter.
+    """
+
+    use ExActor.GenServer, export: __MODULE__
+
+    defstart(start_link(arg), do: initial_state(arg))
+
+    defcast(set(x), do: new_state(x))
+    defcall(get, state: state, do: reply(state))
+  end
 end

--- a/lib/exvcr/adapter.ex
+++ b/lib/exvcr/adapter.ex
@@ -14,8 +14,8 @@ defmodule ExVCR.Adapter do
       @doc """
       Returns list of the mock target methods with function name and callback.
       """
-      def target_methods(recorder), do: raise ExVCR.ImplementationMissingError
-      defoverridable [target_methods: 1]
+      def target_methods(), do: raise ExVCR.ImplementationMissingError
+      defoverridable [target_methods: 0]
 
       @doc """
       Generate key for searching response.

--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -27,17 +27,18 @@ defmodule ExVCR.Adapter.Hackney do
   @doc """
   Returns list of the mock target methods with function name and callback.
   """
-  def target_methods(recorder) do
+  def target_methods() do
     [
-      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3, &4, &5])},
-      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3, &4])},
-      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3])},
-      {:request, &ExVCR.Recorder.request(recorder, [&1, &2])},
-      {:request, &ExVCR.Recorder.request(recorder, [&1])},
-      {:body, &handle_body_request(recorder, [&1])},
-      {:body, &handle_body_request(recorder, [&1, &2])}
+      {:request, &ExVCR.Recorder.request([&1, &2, &3, &4, &5])},
+      {:request, &ExVCR.Recorder.request([&1, &2, &3, &4])},
+      {:request, &ExVCR.Recorder.request([&1, &2, &3])},
+      {:request, &ExVCR.Recorder.request([&1, &2])},
+      {:request, &ExVCR.Recorder.request([&1])},
+      {:body, &handle_body_request([&1])},
+      {:body, &handle_body_request([&1, &2])}
     ]
   end
+
 
   @doc """
   Generate key for searching response.
@@ -87,6 +88,11 @@ defmodule ExVCR.Adapter.Hackney do
       Store.set(client_key_atom, body)
       %{response | body: client}
     end
+  end
+
+  defp handle_body_request(args) do
+    ExVCR.Actor.CurrentRecorder.get()
+    |> handle_body_request(args)
   end
 
   defp handle_body_request(recorder, [client]) do

--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -39,7 +39,6 @@ defmodule ExVCR.Adapter.Hackney do
     ]
   end
 
-
   @doc """
   Generate key for searching response.
   """

--- a/lib/exvcr/adapter/httpc.ex
+++ b/lib/exvcr/adapter/httpc.ex
@@ -27,9 +27,9 @@ defmodule ExVCR.Adapter.Httpc do
       {:request, &ExVCR.Recorder.request(recorder, [&1,&2])}
       {:request, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4,&5])}
   """
-  def target_methods(recorder) do
-    [ {:request, &ExVCR.Recorder.request(recorder, [&1])},
-      {:request, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4])} ]
+  def target_methods() do
+    [ {:request, &ExVCR.Recorder.request([&1])},
+      {:request, &ExVCR.Recorder.request([&1,&2,&3,&4])} ]
   end
 
   @doc """

--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -24,11 +24,11 @@ defmodule ExVCR.Adapter.IBrowse do
   @doc """
   Returns list of the mock target methods with function name and callback.
   """
-  def target_methods(recorder) do
-    [ {:send_req, &ExVCR.Recorder.request(recorder, [&1,&2,&3])},
-      {:send_req, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4])},
-      {:send_req, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4,&5])},
-      {:send_req, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4,&5,&6])} ]
+  def target_methods() do
+    [ {:send_req, &ExVCR.Recorder.request([&1,&2,&3])},
+      {:send_req, &ExVCR.Recorder.request([&1,&2,&3,&4])},
+      {:send_req, &ExVCR.Recorder.request([&1,&2,&3,&4,&5])},
+      {:send_req, &ExVCR.Recorder.request([&1,&2,&3,&4,&5,&6])} ]
   end
 
   @doc """

--- a/lib/exvcr/application.ex
+++ b/lib/exvcr/application.ex
@@ -1,0 +1,21 @@
+defmodule ExVCR.Application do
+  use Application
+
+  def start(_type, _args) do
+    for app <- [:hackney, :ibrowse, :httpc], true == Code.ensure_loaded?(app) do
+      app
+      |> target_methods()
+      |> Enum.each(fn {function, callback} ->
+        :meck.expect(app, function, callback)
+      end)
+    end
+
+    children = [ExVCR.Actor.CurrentRecorder]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: ExVCR.Supervisor)
+  end
+
+  defp target_methods(:hackney), do: ExVCR.Adapter.Hackney.target_methods()
+  defp target_methods(:ibrowse), do: ExVCR.Adapter.IBrowse.target_methods()
+  defp target_methods(:httpc), do: ExVCR.Adapter.Httpc.target_methods()
+end

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -10,6 +10,9 @@ defmodule ExVCR.Handler do
   @doc """
   Get response from either server or cache.
   """
+  def get_response(nil, request) do
+    :meck.passthrough(request)
+  end
   def get_response(recorder, request) do
     if ignore_request?(request, recorder) do
       get_response_from_server(request, recorder, false)

--- a/lib/exvcr/iex.ex
+++ b/lib/exvcr/iex.ex
@@ -24,7 +24,6 @@ defmodule ExVCR.IEx do
             ExVCR.Mock.mock_methods(recorder, unquote(adapter))
             unquote(test)
           after
-            :meck.unload(unquote(adapter).module_name)
             ExVCR.MockLock.release_lock()
             Recorder.get(recorder)
             |> JSX.encode!

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -38,8 +38,6 @@ defmodule ExVCR.Mock do
         [do: return_value] = unquote(test)
         return_value
       after
-        module_name = adapter_method().module_name
-        :meck.unload(module_name)
         ExVCR.MockLock.release_lock()
       end
     end
@@ -68,8 +66,6 @@ defmodule ExVCR.Mock do
       after
         recorder_result = Recorder.save(recorder)
 
-        module_name = adapter_method().module_name
-        :meck.unload(module_name)
         ExVCR.MockLock.release_lock()
 
         recorder_result
@@ -89,19 +85,14 @@ defmodule ExVCR.Mock do
   @doc """
   Mock methods pre-defined for the specified adapter.
   """
-  def mock_methods(recorder, adapter) do
-    target_methods = adapter.target_methods(recorder)
-    module_name    = adapter.module_name
-
+  def mock_methods(recorder, _adapter) do
     parent_pid = self()
     Task.async(fn ->
       ExVCR.MockLock.ensure_started
       ExVCR.MockLock.request_lock(self(), parent_pid)
       receive do
         :lock_granted ->
-          Enum.each(target_methods, fn({function, callback}) ->
-            :meck.expect(module_name, function, callback)
-          end)
+          ExVCR.Actor.CurrentRecorder.set(recorder)
       end
     end)
     |> Task.await(:infinity)

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -38,6 +38,7 @@ defmodule ExVCR.Mock do
         [do: return_value] = unquote(test)
         return_value
       after
+        ExVCR.Actor.CurrentRecorder.set(nil)
         ExVCR.MockLock.release_lock()
       end
     end
@@ -66,6 +67,7 @@ defmodule ExVCR.Mock do
       after
         recorder_result = Recorder.save(recorder)
 
+        ExVCR.Actor.CurrentRecorder.set(nil)
         ExVCR.MockLock.release_lock()
 
         recorder_result

--- a/lib/exvcr/recorder.ex
+++ b/lib/exvcr/recorder.ex
@@ -30,8 +30,9 @@ defmodule ExVCR.Recorder do
   Provides entry point to be called from :meck library. HTTP request arguments are specified as args parameter.
   If response is not found in the cache, access to the server.
   """
-  def request(recorder, request) do
-    Handler.get_response(recorder, request)
+  def request(args) do
+    ExVCR.Actor.CurrentRecorder.get()
+    |> Handler.get_response(args)
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule ExVCR.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    [applications: [:meck, :exactor, :exjsx]]
+    [applications: [:meck, :exactor, :exjsx],
+     mod: {ExVCR.Application, []}]
   end
 
   # Returns the list of dependencies in the format:
@@ -25,7 +26,7 @@ defmodule ExVCR.Mixfile do
       {:meck, "~> 0.8"},
       {:exactor, "~> 2.2"},
       {:exjsx, "~> 4.0"},
-      {:ibrowse, "~> 4.4", optional: true},
+      {:ibrowse, "4.4.0", optional: true},
       {:httpotion, "~> 3.1", optional: true},
       {:httpoison, "~> 1.0", optional: true},
       {:excoveralls, "~> 0.8", only: :test},


### PR DESCRIPTION
Instead of call `:meck.expect` whenever we use cassette, we can implement a global mocking on application startup and global storage for the recorder.  Whenever we need to use a cassette, we can pass the recorder though `CurrentRecorder` GenServer.