### PR TITLE
Make global mock experimental feature and disable it by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,9 @@ otp_release:
   - 19.3
   - 20.3
 
+env:
+  - GLOBAL_MOCK=true
+  - GLOBAL_MOCK=false
+
 script:
   - "MIX_ENV=test mix do deps.get, compile, coveralls.travis"

--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ It's inspired by Ruby's VCR (https://github.com/vcr/vcr), and trying to provide 
     - The JSON file can be recorded automatically (vcr_cassettes) or manually updated (custom_cassettes)
 
 ### Notes
+
 - ExVCR.Config functions must be called from setup or test. Calls outside of test process, such as in setup_all will not work.
-- ExVCR implements global mock, which means that all HTTP client calls outside of `use_cassette` go through `meck.passthough/1`.
 
 ### Install
-Add `:exvcr` to `deps` section of `mix.exs`.
 
 ```elixir
   def deps do
@@ -311,6 +310,39 @@ config :exvcr, [
 ```
 
 If `exvcr` is defined as test-only dependency, describe the above statement in test-only config file (ex. `config\test.exs`) or make it conditional (ex. wrap with `if Mix.env == :test`).
+
+### Global mock experimental feature
+
+The global mock is an attempt to address a general issue with **exvcr being slow**, see [#107](https://github.com/parroty/exvcr/issues/107)
+
+In general, every use_cassette takes around 500 ms so if you extensively use cassettes it could spend minutes doing `:meck.expect/2` and `:meck.unload/1`. Even `exvcr` tests  need 40 seconds versus 1 second when global mock is used.
+
+Since feature is **experimental** be careful when using it. Please note the following:
+
+- ExVCR implements global mock, which means that all HTTP client calls outside of `use_cassette` go through `meck.passthough/1`.
+- There are some report that the feature doesn't work in some case, see [the issue](https://github.com/parroty/exvcr/issues/159).
+- By default, the global mocking disabled, to enabled it set the following in config:
+
+```elixir
+use Mix.Config
+
+config :exvcr, [
+  global_mock: true
+]
+```
+
+All tests that are written for `exvcr` could also be running in global mocking mode:
+
+```
+$ GLOBAL_MOCK=true mix test
+
+.........................................................
+
+Finished in 1.3 seconds
+141 tests, 0 failures
+
+Randomized with seed 905427
+```
 
 ### Mix Tasks
 The following tasks are added by including exvcr package.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
 config :exvcr, [
+  global_mock: false,
   vcr_cassette_library_dir: "fixture/vcr_cassettes",
   custom_cassette_library_dir: "fixture/custom_cassettes",
   filter_sensitive_data: [
@@ -13,3 +14,5 @@ config :exvcr, [
   enable_global_settings: false,
   strict_mode: false
 ]
+
+if Mix.env == :test, do: import_config "test.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :exvcr, [
+  global_mock: System.get_env("GLOBAL_MOCK") == "true"
+]

--- a/lib/exvcr/adapter.ex
+++ b/lib/exvcr/adapter.ex
@@ -13,9 +13,16 @@ defmodule ExVCR.Adapter do
 
       @doc """
       Returns list of the mock target methods with function name and callback.
+      Implementation for global mock.
       """
       def target_methods(), do: raise ExVCR.ImplementationMissingError
       defoverridable [target_methods: 0]
+
+      @doc """
+      Returns list of the mock target methods with function name and callback.
+      """
+      def target_methods(recorder), do: raise ExVCR.ImplementationMissingError
+      defoverridable [target_methods: 1]
 
       @doc """
       Generate key for searching response.

--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -26,6 +26,7 @@ defmodule ExVCR.Adapter.Hackney do
 
   @doc """
   Returns list of the mock target methods with function name and callback.
+  Implementation for global mock.
   """
   def target_methods() do
     [
@@ -36,6 +37,21 @@ defmodule ExVCR.Adapter.Hackney do
       {:request, &ExVCR.Recorder.request([&1])},
       {:body, &handle_body_request([&1])},
       {:body, &handle_body_request([&1, &2])}
+    ]
+  end
+
+  @doc """
+  Returns list of the mock target methods with function name and callback.
+  """
+  def target_methods(recorder) do
+    [
+      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3, &4, &5])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3, &4])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1, &2, &3])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1, &2])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1])},
+      {:body, &handle_body_request(recorder, [&1])},
+      {:body, &handle_body_request(recorder, [&1, &2])}
     ]
   end
 

--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -110,6 +110,10 @@ defmodule ExVCR.Adapter.Hackney do
     |> handle_body_request(args)
   end
 
+  defp handle_body_request(nil, args) do
+    :meck.passthrough(args)
+  end
+
   defp handle_body_request(recorder, [client]) do
     handle_body_request(recorder, [client, :infinity])
   end

--- a/lib/exvcr/adapter/httpc.ex
+++ b/lib/exvcr/adapter/httpc.ex
@@ -23,6 +23,7 @@ defmodule ExVCR.Adapter.Httpc do
 
   @doc """
   Returns list of the mock target methods with function name and callback.
+  Implementation for global mock.
     TODO:
       {:request, &ExVCR.Recorder.request(recorder, [&1,&2])}
       {:request, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4,&5])}
@@ -31,6 +32,18 @@ defmodule ExVCR.Adapter.Httpc do
     [ {:request, &ExVCR.Recorder.request([&1])},
       {:request, &ExVCR.Recorder.request([&1,&2,&3,&4])} ]
   end
+
+  @doc """
+  Returns list of the mock target methods with function name and callback.
+    TODO:
+      {:request, &ExVCR.Recorder.request(recorder, [&1,&2])}
+      {:request, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4,&5])}
+  """
+  def target_methods(recorder) do
+    [ {:request, &ExVCR.Recorder.request(recorder, [&1])},
+      {:request, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4])} ]
+  end
+
 
   @doc """
   Generate key for searching response.

--- a/lib/exvcr/adapter/ibrowse.ex
+++ b/lib/exvcr/adapter/ibrowse.ex
@@ -23,12 +23,23 @@ defmodule ExVCR.Adapter.IBrowse do
 
   @doc """
   Returns list of the mock target methods with function name and callback.
+  Implementation for global mock.
   """
   def target_methods() do
     [ {:send_req, &ExVCR.Recorder.request([&1,&2,&3])},
       {:send_req, &ExVCR.Recorder.request([&1,&2,&3,&4])},
       {:send_req, &ExVCR.Recorder.request([&1,&2,&3,&4,&5])},
       {:send_req, &ExVCR.Recorder.request([&1,&2,&3,&4,&5,&6])} ]
+  end
+
+  @doc """
+  Returns list of the mock target methods with function name and callback.
+  """
+  def target_methods(recorder) do
+    [ {:send_req, &ExVCR.Recorder.request(recorder, [&1,&2,&3])},
+      {:send_req, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4])},
+      {:send_req, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4,&5])},
+      {:send_req, &ExVCR.Recorder.request(recorder, [&1,&2,&3,&4,&5,&6])} ]
   end
 
   @doc """

--- a/lib/exvcr/application.ex
+++ b/lib/exvcr/application.ex
@@ -2,6 +2,18 @@ defmodule ExVCR.Application do
   use Application
 
   def start(_type, _args) do
+    children =
+      if global_mock_enabled?() do
+        globally_mock_adapters()
+        [ExVCR.Actor.CurrentRecorder]
+      else
+        []
+      end
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: ExVCR.Supervisor)
+  end
+
+  defp globally_mock_adapters do
     for app <- [:hackney, :ibrowse, :httpc], true == Code.ensure_loaded?(app) do
       app
       |> target_methods()
@@ -9,13 +21,14 @@ defmodule ExVCR.Application do
         :meck.expect(app, function, callback)
       end)
     end
-
-    children = [ExVCR.Actor.CurrentRecorder]
-
-    Supervisor.start_link(children, strategy: :one_for_one, name: ExVCR.Supervisor)
   end
+
 
   defp target_methods(:hackney), do: ExVCR.Adapter.Hackney.target_methods()
   defp target_methods(:ibrowse), do: ExVCR.Adapter.IBrowse.target_methods()
   defp target_methods(:httpc), do: ExVCR.Adapter.Httpc.target_methods()
+
+  def global_mock_enabled? do
+    Application.get_env(:exvcr, :global_mock, false)
+  end
 end

--- a/lib/exvcr/recorder.ex
+++ b/lib/exvcr/recorder.ex
@@ -29,10 +29,19 @@ defmodule ExVCR.Recorder do
   @doc """
   Provides entry point to be called from :meck library. HTTP request arguments are specified as args parameter.
   If response is not found in the cache, access to the server.
+  Implementation for global mock.
   """
-  def request(args) do
+  def request(request) do
     ExVCR.Actor.CurrentRecorder.get()
-    |> Handler.get_response(args)
+    |> request(request)
+  end
+
+  @doc """
+  Provides entry point to be called from :meck library. HTTP request arguments are specified as args parameter.
+  If response is not found in the cache, access to the server.
+  """
+  def request(recorder, request) do
+    Handler.get_response(recorder, request)
   end
 
   @doc """


### PR DESCRIPTION
Even though all tests passed and the global mock was tested with an external application,
it was pretty optimistic to enabled that by default.
This commit changes default behavior that mocks every cassette and adds an ability to enable
the experimental feature. To do so, extend your `test.exs`:

```elixir
config :exvcr, [
  global_mock: true
]
```

In Travis CI we run the same test for both default behavior and global
mock.