### PR TITLE
Fix CurrentRecorder initial state

### DIFF
--- a/lib/exvcr/actor.ex
+++ b/lib/exvcr/actor.ex
@@ -55,9 +55,11 @@ defmodule ExVCR.Actor do
 
     use ExActor.GenServer, export: __MODULE__
 
-    defstart(start_link(arg), do: initial_state(arg))
+    defstart(start_link(_arg), do: default_state() |> initial_state())
 
     defcast(set(x), do: new_state(x))
     defcall(get, state: state, do: reply(state))
+
+    def default_state(), do: nil
   end
 end

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -102,7 +102,8 @@ defmodule ExVCR.Mock do
   @doc false
   def unload(module_name) do
     if ExVCR.Application.global_mock_enabled?() do
-      ExVCR.Actor.CurrentRecorder.set(nil)
+      ExVCR.Actor.CurrentRecorder.default_state()
+      |> ExVCR.Actor.CurrentRecorder.set()
     else
       :meck.unload(module_name)
     end

--- a/test/adapter_hackney_test.exs
+++ b/test/adapter_hackney_test.exs
@@ -13,6 +13,16 @@ defmodule ExVCR.Adapter.HackneyTest do
     :ok
   end
 
+  test "passthrough works when CurrentRecorder has an initial state" do
+    if ExVCR.Application.global_mock_enabled?() do
+      ExVCR.Actor.CurrentRecorder.default_state()
+      |> ExVCR.Actor.CurrentRecorder.set()
+    end
+    url = "http://localhost:#{@port}/server"
+    {:ok, status_code, _headers, _body} = :hackney.request(:get, url, [], [], [with_body: true])
+    assert status_code == 200
+  end
+
   test "passthrough works after cassette has been used" do
     url = "http://localhost:#{@port}/server"
     use_cassette "hackney_get_localhost" do

--- a/test/adapter_httpc_test.exs
+++ b/test/adapter_httpc_test.exs
@@ -13,6 +13,17 @@ defmodule ExVCR.Adapter.HttpcTest do
     :ok
   end
 
+  test "passthrough works when CurrentRecorder has an initial state" do
+    if ExVCR.Application.global_mock_enabled?() do
+      ExVCR.Actor.CurrentRecorder.default_state()
+      |> ExVCR.Actor.CurrentRecorder.set()
+    end
+    url = "http://localhost:#{@port}/server" |> to_char_list()
+    {:ok, result} = :httpc.request(url)
+    {{_http_version, status_code, _reason_phrase}, _headers, _body} = result
+    assert status_code == 200
+  end
+
   test "passthrough works after cassette has been used" do
     url = "http://localhost:#{@port}/server" |> to_char_list()
     use_cassette "httpc_get_localhost" do

--- a/test/adapter_ibrowse_test.exs
+++ b/test/adapter_ibrowse_test.exs
@@ -13,6 +13,15 @@ defmodule ExVCR.Adapter.IBrowseTest do
     :ok
   end
 
+  test "passthrough works when CurrentRecorder has an initial state" do
+    if ExVCR.Application.global_mock_enabled?() do
+      ExVCR.Actor.CurrentRecorder.default_state()
+      |> ExVCR.Actor.CurrentRecorder.set()
+    end
+    url = "http://localhost:#{@port}/server" |> to_char_list()
+    {:ok, status_code, _headers, _body} = :ibrowse.send_req(url, [], :get)
+    assert status_code == '200'
+  end
 
   test "passthrough works after cassette has been used" do
     url = "http://localhost:#{@port}/server" |> to_char_list()


### PR DESCRIPTION
The initial state should be `nil` to properly bypass mock when no cassette is used.

See https://github.com/parroty/exvcr/issues/159#issuecomment-726233421