### PR TITLE
Fix test errors and warnings

### DIFF
--- a/test/adapter_httpc_test.exs
+++ b/test/adapter_httpc_test.exs
@@ -18,14 +18,14 @@ defmodule ExVCR.Adapter.HttpcTest do
       ExVCR.Actor.CurrentRecorder.default_state()
       |> ExVCR.Actor.CurrentRecorder.set()
     end
-    url = "http://localhost:#{@port}/server" |> to_char_list()
+    url = "http://localhost:#{@port}/server" |> to_charlist()
     {:ok, result} = :httpc.request(url)
     {{_http_version, status_code, _reason_phrase}, _headers, _body} = result
     assert status_code == 200
   end
 
   test "passthrough works after cassette has been used" do
-    url = "http://localhost:#{@port}/server" |> to_char_list()
+    url = "http://localhost:#{@port}/server" |> to_charlist()
     use_cassette "httpc_get_localhost" do
       {:ok, result} = :httpc.request(url)
       {{_http_version, status_code, _reason_phrase}, _headers, _body} = result

--- a/test/adapter_ibrowse_test.exs
+++ b/test/adapter_ibrowse_test.exs
@@ -18,13 +18,13 @@ defmodule ExVCR.Adapter.IBrowseTest do
       ExVCR.Actor.CurrentRecorder.default_state()
       |> ExVCR.Actor.CurrentRecorder.set()
     end
-    url = "http://localhost:#{@port}/server" |> to_char_list()
+    url = "http://localhost:#{@port}/server" |> to_charlist()
     {:ok, status_code, _headers, _body} = :ibrowse.send_req(url, [], :get)
     assert status_code == '200'
   end
 
   test "passthrough works after cassette has been used" do
-    url = "http://localhost:#{@port}/server" |> to_char_list()
+    url = "http://localhost:#{@port}/server" |> to_charlist()
     use_cassette "ibrowse_get_localhost" do
       {:ok, status_code, _headers, _body} = :ibrowse.send_req(url, [], :get)
       assert status_code == '200'

--- a/test/recorder_httpc_test.exs
+++ b/test/recorder_httpc_test.exs
@@ -117,7 +117,7 @@ defmodule ExVCR.RecorderHttpcTest do
     ExVCR.Config.response_headers_blacklist(["Date"])
     use_cassette "remove_blacklisted_headers" do
       {:ok, {_, headers, _}} = :httpc.request(@url)
-      assert headers == [{'server', 'Cowboy'}, {'content-length', '13'}]
+      assert Enum.sort(headers) == Enum.sort([{'server', 'Cowboy'}, {'content-length', '13'}])
     end
     ExVCR.Config.response_headers_blacklist([])
   end


### PR DESCRIPTION
## Changes
### 1. Fix for occasional error due to different ordering of multiple headers.

```elixir
  1) test remove blacklisted headers (ExVCR.RecorderHttpcTest)
     test/recorder_httpc_test.exs:116
     Assertion with == failed
     code:  assert headers == [{'server', 'Cowboy'}, {'content-length', '13'}]
     left:  [{'content-length', '13'}, {'server', 'Cowboy'}]
     right: [{'server', 'Cowboy'}, {'content-length', '13'}]
     stacktrace:
       test/recorder_httpc_test.exs:120: (test)
```

### 2. Fix for Kernel.to_char_list/1  deprecation warnings.

```elixir
Generated exvcr app
warning: Kernel.to_char_list/1 is deprecated, use Kernel.to_charlist/1 instead
  test/adapter_httpc_test.exs:21: ExVCR.Adapter.HttpcTest."test passthrough works when CurrentRecorder has an initial state"/1

warning: Kernel.to_char_list/1 is deprecated, use Kernel.to_charlist/1 instead
  test/adapter_httpc_test.exs:28: ExVCR.Adapter.HttpcTest."test passthrough works after cassette has been used"/1
```

