### PR TITLE
Resolve Duplicate Docs Warnings

### DIFF
--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -25,7 +25,14 @@ defmodule ExVCR.Mock do
   end
 
   @doc """
-  Provides macro to mock response based on specified parameters.
+  Provides macro to trigger recording/replaying http interactions.
+
+  ## Options
+
+  - `:match_requests_on` A list of request properties to match on when
+    finding a matching response. Valid values include `:query`, `:headers`,
+    and `:request_body`
+
   """
   defmacro use_cassette(:stub, options, test) do
     quote do
@@ -45,16 +52,6 @@ defmodule ExVCR.Mock do
     end
   end
 
-  @doc """
-  Provides macro to trigger recording/replaying http interactions.
-
-  ## Options
-
-  - `:match_requests_on` A list of request properties to match on when
-    finding a matching response. Valid values include `:query`, `:headers`,
-    and `:request_body`
-
-  """
   defmacro use_cassette(fixture, options, test) do
     quote do
       recorder = Recorder.start(
@@ -77,9 +74,6 @@ defmodule ExVCR.Mock do
     end
   end
 
-  @doc """
-  Provides macro to trigger recording/replaying http interactions with default options.
-  """
   defmacro use_cassette(fixture, test) do
     quote do
       use_cassette(unquote(fixture), [], unquote(test))


### PR DESCRIPTION
Warnings were being issued regarding duplicate documentation
declarations. Here's an example:

```
warning: redefining @doc attribute previously set at line 27.

Please remove the duplicate docs. If instead you want to override a previously defined @doc, attach the @doc attribute to a function head (the function signature not followed by any do-block). For example:

    @doc """
    new docs
    """
    def use_cassette(...)

  lib/exvcr/mock.ex:48: ExVCR.Mock.use_cassette/3
```

This change resolves these warnings by merging documentation and adding
examples that were already available in the README file.