### PR TITLE
Add example for Finch stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,18 @@ test "stub request works for httpc" do
   {{_http_version, _status_code = 200, _reason_phrase}, _headers, body} = result
   assert to_string(body) == "success!"
 end
+
+test "stub request works for Finch" do
+  use_cassette :stub, [url: "http://www.example.com",
+                       method: "get",
+                       status_code: 200,
+                       body: "Stub Response"] do
+
+  {:ok, response} = Finch.build(:get, "http://example.com/") |> Finch.request(MyFinch)
+  assert response.body =~ ~r/Stub Response/
+  assert Map.new(response.headers)["content-type"] == "text/html"
+  assert response.status_code == 200
+end
 ```
 
 If the specified `:url` parameter doesn't match requests called inside the


### PR DESCRIPTION
Using VCR is very easy to get it working following the readme. The stubs are easy to produce a 404/500 but not all of the information is available in the readme. The tests show how other libraries can be used such as Finch. I have added a few lines for Finch with stub as this is the one I was using.