### PR TITLE
Adds httpoison ~> 2.0 support

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule ExVCR.Mixfile do
       {:exjsx, "~> 4.0"},
       {:ibrowse, "4.4.0", optional: true},
       {:httpotion, "~> 3.1", optional: true},
-      {:httpoison, "~> 1.0", optional: true},
+      {:httpoison, "~> 1.0 or ~> 2.0", optional: true},
       {:finch, "~> 0.8", optional: true},
       {:excoveralls, "~> 0.14", only: :test},
       {:http_server, github: "parroty/http_server", only: [:dev, :test]},


### PR DESCRIPTION
Hey there! 🖖 

This PR simply loosens the `httpoison ~> 1.0` constraint. 

The breaking changes from [httpoison](https://hex.pm/packages/httpoison) 1.8.2 to 2.0 are related to SSL options - which are not used by exvcr. Therefore, loosening the constraint shouldn't have any collateral effect on exvcr.

For more details about the breaking changes, see [httpoison 2.0.0 release](https://github.com/edgurgel/httpoison/releases/tag/v2.0.0). 

Closes #195 