### PR TITLE
Fix workflow cache to consider otp/elixir versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-
+            ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
       - run: mix deps.get
       - uses: nick-invision/retry@v2
         with:


### PR DESCRIPTION
Trial to workflow error caused by incorrect otp version.

ex. 
```
Error: 12:58:24.125 [error] beam/beam_load.c(1871): Error loading module jsx:
  This BEAM file was compiled for a later version of the run-time system than 21.
  To fix this, please recompile this module with an 21 compiler.
  (Use of opcode 169; this emulator supports only up to 163.)
```