### PR TITLE
Fix Elixir 1.14 warnings

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :exvcr, [
   global_mock: false,

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :exvcr, [
   global_mock: System.get_env("GLOBAL_MOCK") == "true"

--- a/lib/exvcr/adapter/hackney/converter.ex
+++ b/lib/exvcr/adapter/hackney/converter.ex
@@ -1,113 +1,113 @@
-if Code.ensure_loaded?(:hackney) do
-  defmodule ExVCR.Adapter.Hackney.Converter do
-    @moduledoc """
-    Provides helpers to mock :hackney methods.
-    """
+defmodule ExVCR.Adapter.Hackney.Converter do
+  @moduledoc """
+  Provides helpers to mock :hackney methods.
+  """
 
-    use ExVCR.Converter
+  use ExVCR.Converter
 
-    defp string_to_response(string) do
-      response = Enum.map(string, fn {x, y} -> {String.to_atom(x), y} end)
-      response = struct(ExVCR.Response, response)
+  defp string_to_response(string) do
+    response = Enum.map(string, fn {x, y} -> {String.to_atom(x), y} end)
+    response = struct(ExVCR.Response, response)
 
-      response =
-        if is_map(response.headers) do
-          headers = response.headers |> Map.to_list()
-          %{response | headers: headers}
-        else
-          response
-        end
+    response =
+      if is_map(response.headers) do
+        headers = response.headers |> Map.to_list()
+        %{response | headers: headers}
+      else
+        response
+      end
 
-      response
-    end
-
-    defp request_to_string(request) do
-      method = Enum.fetch!(request, 0) |> to_string()
-      url = Enum.fetch!(request, 1) |> parse_url()
-      headers = Enum.at(request, 2, []) |> parse_headers()
-      body = Enum.at(request, 3, "") |> parse_request_body()
-      options = Enum.at(request, 4, []) |> sanitize_options() |> parse_options()
-
-      %ExVCR.Request{
-        url: url,
-        headers: headers,
-        method: method,
-        body: body,
-        options: options
-      }
-    end
-
-    # Sanitize options so that they can be encoded as json.
-    defp sanitize_options(options) do
-      Enum.map(options, &do_sanitize/1)
-    end
-
-    defp do_sanitize({key, value}) when is_function(key) do
-      {inspect(key), value}
-    end
-
-    defp do_sanitize({key, value}) when is_list(value) do
-      {key, Enum.map(value, &do_sanitize/1)}
-    end
-
-    defp do_sanitize({key, value}) when is_tuple(value) do
-      {key, Tuple.to_list(do_sanitize(value))}
-    end
-
-    defp do_sanitize({key, value}) when is_function(value) do
-      {key, inspect(value)}
-    end
-
-    defp do_sanitize({key, value}) do
-      {key, value}
-    end
-
-    defp do_sanitize(key) when is_atom(key) do
-      {key, true}
-    end
-
-    defp do_sanitize(value) do
-      value
-    end
-
-    defp response_to_string({:ok, status_code, headers, body_or_client}) do
-      body =
-        case body_or_client do
-          string when is_binary(string) -> string
-          # Client is already replaced by body through ExVCR.Adapter.Hackney adapter.
-          ref when is_reference(ref) -> inspect(ref)
-        end
-
-      %ExVCR.Response{
-        type: "ok",
-        status_code: status_code,
-        headers: parse_headers(headers),
-        body: body
-      }
-    end
-
-    defp response_to_string({:ok, status_code, headers}) do
-      %ExVCR.Response{
-        type: "ok",
-        status_code: status_code,
-        headers: parse_headers(headers)
-      }
-    end
-
-    defp response_to_string({:error, reason}) do
-      %ExVCR.Response{
-        type: "error",
-        body: Atom.to_string(reason)
-      }
-    end
-
-    def parse_request_body({:form, body}) do
-      :hackney_request.encode_form(body)
-      |> elem(2)
-      |> to_string
-      |> ExVCR.Filter.filter_sensitive_data()
-    end
-
-    def parse_request_body(body), do: super(body)
+    response
   end
+
+  defp request_to_string(request) do
+    method = Enum.fetch!(request, 0) |> to_string()
+    url = Enum.fetch!(request, 1) |> parse_url()
+    headers = Enum.at(request, 2, []) |> parse_headers()
+    body = Enum.at(request, 3, "") |> parse_request_body()
+    options = Enum.at(request, 4, []) |> sanitize_options() |> parse_options()
+
+    %ExVCR.Request{
+      url: url,
+      headers: headers,
+      method: method,
+      body: body,
+      options: options
+    }
+  end
+
+  # Sanitize options so that they can be encoded as json.
+  defp sanitize_options(options) do
+    Enum.map(options, &do_sanitize/1)
+  end
+
+  defp do_sanitize({key, value}) when is_function(key) do
+    {inspect(key), value}
+  end
+
+  defp do_sanitize({key, value}) when is_list(value) do
+    {key, Enum.map(value, &do_sanitize/1)}
+  end
+
+  defp do_sanitize({key, value}) when is_tuple(value) do
+    {key, Tuple.to_list(do_sanitize(value))}
+  end
+
+  defp do_sanitize({key, value}) when is_function(value) do
+    {key, inspect(value)}
+  end
+
+  defp do_sanitize({key, value}) do
+    {key, value}
+  end
+
+  defp do_sanitize(key) when is_atom(key) do
+    {key, true}
+  end
+
+  defp do_sanitize(value) do
+    value
+  end
+
+  defp response_to_string({:ok, status_code, headers, body_or_client}) do
+    body =
+      case body_or_client do
+        string when is_binary(string) -> string
+        # Client is already replaced by body through ExVCR.Adapter.Hackney adapter.
+        ref when is_reference(ref) -> inspect(ref)
+      end
+
+    %ExVCR.Response{
+      type: "ok",
+      status_code: status_code,
+      headers: parse_headers(headers),
+      body: body
+    }
+  end
+
+  defp response_to_string({:ok, status_code, headers}) do
+    %ExVCR.Response{
+      type: "ok",
+      status_code: status_code,
+      headers: parse_headers(headers)
+    }
+  end
+
+  defp response_to_string({:error, reason}) do
+    %ExVCR.Response{
+      type: "error",
+      body: Atom.to_string(reason)
+    }
+  end
+
+  def parse_request_body({:form, body}) do
+    hackney_request_module().encode_form(body)
+    |> elem(2)
+    |> to_string
+    |> ExVCR.Filter.filter_sensitive_data()
+  end
+
+  def parse_request_body(body), do: super(body)
+
+  defp hackney_request_module(), do: :hackney_request
 end

--- a/lib/exvcr/adapter/hackney/converter.ex
+++ b/lib/exvcr/adapter/hackney/converter.ex
@@ -1,111 +1,113 @@
-defmodule ExVCR.Adapter.Hackney.Converter do
-  @moduledoc """
-  Provides helpers to mock :hackney methods.
-  """
+if Code.ensure_loaded?(:hackney) do
+  defmodule ExVCR.Adapter.Hackney.Converter do
+    @moduledoc """
+    Provides helpers to mock :hackney methods.
+    """
 
-  use ExVCR.Converter
+    use ExVCR.Converter
 
-  defp string_to_response(string) do
-    response = Enum.map(string, fn {x, y} -> {String.to_atom(x), y} end)
-    response = struct(ExVCR.Response, response)
+    defp string_to_response(string) do
+      response = Enum.map(string, fn {x, y} -> {String.to_atom(x), y} end)
+      response = struct(ExVCR.Response, response)
 
-    response =
-      if is_map(response.headers) do
-        headers = response.headers |> Map.to_list()
-        %{response | headers: headers}
-      else
-        response
-      end
+      response =
+        if is_map(response.headers) do
+          headers = response.headers |> Map.to_list()
+          %{response | headers: headers}
+        else
+          response
+        end
 
-    response
+      response
+    end
+
+    defp request_to_string(request) do
+      method = Enum.fetch!(request, 0) |> to_string()
+      url = Enum.fetch!(request, 1) |> parse_url()
+      headers = Enum.at(request, 2, []) |> parse_headers()
+      body = Enum.at(request, 3, "") |> parse_request_body()
+      options = Enum.at(request, 4, []) |> sanitize_options() |> parse_options()
+
+      %ExVCR.Request{
+        url: url,
+        headers: headers,
+        method: method,
+        body: body,
+        options: options
+      }
+    end
+
+    # Sanitize options so that they can be encoded as json.
+    defp sanitize_options(options) do
+      Enum.map(options, &do_sanitize/1)
+    end
+
+    defp do_sanitize({key, value}) when is_function(key) do
+      {inspect(key), value}
+    end
+
+    defp do_sanitize({key, value}) when is_list(value) do
+      {key, Enum.map(value, &do_sanitize/1)}
+    end
+
+    defp do_sanitize({key, value}) when is_tuple(value) do
+      {key, Tuple.to_list(do_sanitize(value))}
+    end
+
+    defp do_sanitize({key, value}) when is_function(value) do
+      {key, inspect(value)}
+    end
+
+    defp do_sanitize({key, value}) do
+      {key, value}
+    end
+
+    defp do_sanitize(key) when is_atom(key) do
+      {key, true}
+    end
+
+    defp do_sanitize(value) do
+      value
+    end
+
+    defp response_to_string({:ok, status_code, headers, body_or_client}) do
+      body =
+        case body_or_client do
+          string when is_binary(string) -> string
+          # Client is already replaced by body through ExVCR.Adapter.Hackney adapter.
+          ref when is_reference(ref) -> inspect(ref)
+        end
+
+      %ExVCR.Response{
+        type: "ok",
+        status_code: status_code,
+        headers: parse_headers(headers),
+        body: body
+      }
+    end
+
+    defp response_to_string({:ok, status_code, headers}) do
+      %ExVCR.Response{
+        type: "ok",
+        status_code: status_code,
+        headers: parse_headers(headers)
+      }
+    end
+
+    defp response_to_string({:error, reason}) do
+      %ExVCR.Response{
+        type: "error",
+        body: Atom.to_string(reason)
+      }
+    end
+
+    def parse_request_body({:form, body}) do
+      :hackney_request.encode_form(body)
+      |> elem(2)
+      |> to_string
+      |> ExVCR.Filter.filter_sensitive_data()
+    end
+
+    def parse_request_body(body), do: super(body)
   end
-
-  defp request_to_string(request) do
-    method = Enum.fetch!(request, 0) |> to_string()
-    url = Enum.fetch!(request, 1) |> parse_url()
-    headers = Enum.at(request, 2, []) |> parse_headers()
-    body = Enum.at(request, 3, "") |> parse_request_body()
-    options = Enum.at(request, 4, []) |> sanitize_options() |> parse_options()
-
-    %ExVCR.Request{
-      url: url,
-      headers: headers,
-      method: method,
-      body: body,
-      options: options
-    }
-  end
-
-  # Sanitize options so that they can be encoded as json.
-  defp sanitize_options(options) do
-    Enum.map(options, &do_sanitize/1)
-  end
-
-  defp do_sanitize({key, value}) when is_function(key) do
-    {inspect(key), value}
-  end
-
-  defp do_sanitize({key, value}) when is_list(value) do
-    {key, Enum.map(value, &do_sanitize/1)}
-  end
-
-  defp do_sanitize({key, value}) when is_tuple(value) do
-    {key, Tuple.to_list(do_sanitize(value))}
-  end
-
-  defp do_sanitize({key, value}) when is_function(value) do
-    {key, inspect(value)}
-  end
-
-  defp do_sanitize({key, value}) do
-    {key, value}
-  end
-
-  defp do_sanitize(key) when is_atom(key) do
-    {key, true}
-  end
-
-  defp do_sanitize(value) do
-    value
-  end
-
-  defp response_to_string({:ok, status_code, headers, body_or_client}) do
-    body =
-      case body_or_client do
-        string when is_binary(string) -> string
-        # Client is already replaced by body through ExVCR.Adapter.Hackney adapter.
-        ref when is_reference(ref) -> inspect(ref)
-      end
-
-    %ExVCR.Response{
-      type: "ok",
-      status_code: status_code,
-      headers: parse_headers(headers),
-      body: body
-    }
-  end
-
-  defp response_to_string({:ok, status_code, headers}) do
-    %ExVCR.Response{
-      type: "ok",
-      status_code: status_code,
-      headers: parse_headers(headers)
-    }
-  end
-
-  defp response_to_string({:error, reason}) do
-    %ExVCR.Response{
-      type: "error",
-      body: Atom.to_string(reason)
-    }
-  end
-
-  def parse_request_body({:form, body}) do
-    :hackney_request.encode_form(body)
-    |> elem(2)
-    |> to_string
-    |> ExVCR.Filter.filter_sensitive_data()
-  end
-
-  def parse_request_body(body), do: super(body)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -20,10 +20,7 @@ defmodule ExVCR.Mixfile do
   end
 
   def application do
-    [
-      applications: [:meck, :exactor, :exjsx, :hackney],
-      mod: {ExVCR.Application, []}
-    ]
+    [applications: [:meck, :exactor, :exjsx], mod: {ExVCR.Application, []}]
   end
 
   def deps do

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,10 @@ defmodule ExVCR.Mixfile do
   end
 
   def application do
-    [applications: [:meck, :exactor, :exjsx], mod: {ExVCR.Application, []}]
+    [
+      applications: [:meck, :exactor, :exjsx, :hackney],
+      mod: {ExVCR.Application, []}
+    ]
   end
 
   def deps do


### PR DESCRIPTION
This PR fixes all warnings emitted by Elixir 1.14.5 (Erlang 25). Probably should be squashed during merge.

```
warning: use Mix.Config is deprecated. Use the Config module instead
  config/config.exs:1
```

```
warning: :hackney_request.encode_form/1 defined in application :hackney is used by the current application but the current application does not depend on :hackney. To fix this, you must do one of:

  1. If :hackney is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :hackney is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :hackney, you may optionally skip this warning by adding [xref: [exclude: [:hackney_request]]] to your "def project" in mix.exs

  lib/exvcr/adapter/hackney/converter.ex:104: ExVCR.Adapter.Hackney.Converter.parse_request_body/1
```