### PR TITLE
fix: Allow numeric options

### DIFF
--- a/lib/exvcr/filter.ex
+++ b/lib/exvcr/filter.ex
@@ -6,13 +6,14 @@ defmodule ExVCR.Filter do
   @doc """
   Filter out senstive data from the response.
   """
-  def filter_sensitive_data(body) do
+  def filter_sensitive_data(body) when is_binary(body) do
     if String.valid?(body) do
       replace(body, ExVCR.Setting.get(:filter_sensitive_data))
     else
       body
     end
   end
+  def filter_sensitive_data(body), do: body
 
   @doc """
   Filter out senstive data from the request header.

--- a/test/filter_test.exs
+++ b/test/filter_test.exs
@@ -13,6 +13,10 @@ defmodule ExVCR.FilterTest do
     ExVCR.Config.filter_sensitive_data(nil)
   end
 
+  test "filter_sensitive_data handles non string values" do
+    assert ExVCR.Filter.filter_sensitive_data(60_000) ==  60000
+  end
+
   test "filter_url_params" do
     url = "https://example.com/api?test1=foo&test2=bar"
 


### PR DESCRIPTION
This PR allows for values other than strings to be passed in to `Filter.filter_sensitive_data/1`

Closes: https://github.com/parroty/exvcr/issues/208 

