### PR TITLE
Add support for Maps on request_body matcher

### DIFF
--- a/test/handler_stub_mode_test.exs
+++ b/test/handler_stub_mode_test.exs
@@ -47,6 +47,14 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
     end
   end
 
+  test "request_body matches as map" do
+    use_cassette :stub, [url: 'http://localhost', method: :post, request_body: "%{param1: \"value1\", param2: \"value2\"}", body: "Hello World"] do
+      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost', [], :post, '{"param1":"value1", "param2":"value2"}')
+      assert status_code == '200'
+      assert to_string(body) =~ ~r/Hello World/
+    end
+  end
+
   test "request_body mismatches as regex" do
     assert_raise ExVCR.InvalidRequestError, fn ->
       use_cassette :stub, [url: 'http://localhost', method: :post, request_body: "~r/param3/", body: "Hello World"] do


### PR DESCRIPTION
Hello there! 👋 
First of all thanks for maintaining this library! It's awesome and I use it a lot!

I've noticed that after upgrading to Elixir 1.15 - OTP 26 some tests started failing due to the order of keys/values changing when encoding the JSON body.

I know I can write a custom matcher or try to write a regexp but I believe this may be useful to more people too.
Would such feature be of interest?

This PR implementation is not ideal so please let me know what implementation would you prefer in case you like the feature. I also thought about adding a new option like `:request_on_json_body`. I'm open to suggestions.
