### PR TITLE
Normalizes request body and URL by parsing params to a list and sorting

### DIFF
--- a/fixture/custom_cassettes/response_mocking_with_param.json
+++ b/fixture/custom_cassettes/response_mocking_with_param.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "url": "http://example.com?auth_token=123abc",
+      "url": "http://example.com?auth_token=123abc&another_param=456",
       "method": "get"
     },
     "response": {

--- a/fixture/vcr_cassettes/different_query_params_on.json
+++ b/fixture/vcr_cassettes/different_query_params_on.json
@@ -5,7 +5,7 @@
       "headers": [],
       "method": "get",
       "options": [],
-      "url": "http://localhost:34006/server?p=3"
+      "url": "http://localhost:34006/server?p=3&q=string"
     },
     "response": {
       "body": "test_response_before",

--- a/lib/exvcr/handler.ex
+++ b/lib/exvcr/handler.ex
@@ -170,11 +170,18 @@ defmodule ExVCR.Handler do
         pattern = Regex.compile!(Enum.at(match, 1))
         Regex.match?(pattern, key_body)
       else
-        request_body == key_body
+        normalize_request_body(request_body) == normalize_request_body(key_body)
       end
     else
       true
     end
+  end
+  
+  defp normalize_request_body(request_body) do
+    request_body
+    |> URI.decode_query()
+    |> Map.to_list()
+    |> Enum.sort_by(fn {key, _val} -> key end)
   end
 
   defp get_response_from_server(request, recorder, record?) do

--- a/test/handler_custom_mode_test.exs
+++ b/test/handler_custom_mode_test.exs
@@ -4,10 +4,9 @@ defmodule ExVCR.Adapter.HandlerCustomModeTest do
 
   test "query param match succeeds with custom mode" do
     use_cassette "response_mocking_with_param", custom: true do
-      HTTPotion.get("http://example.com?auth_token=123abc", []).body =~ ~r/Custom Response/
+      HTTPotion.get("http://example.com?another_param=456&auth_token=123abc", []).body =~ ~r/Custom Response/
     end
   end
-
 
   test "custom with valid response" do
     use_cassette "response_mocking", custom: true do

--- a/test/handler_options_test.exs
+++ b/test/handler_options_test.exs
@@ -17,7 +17,7 @@ defmodule ExVCR.Adapter.HandlerOptionsTest do
     test "specifying match_requests_on: [:query] matches query params" do
       use_cassette "different_query_params_on", match_requests_on: [:query] do
         HttpServer.start(path: "/server", port: @port, response: "test_response_before")
-        assert HTTPotion.get("#{@url}?p=3", []).body =~ ~r/test_response_before/
+        assert HTTPotion.get("#{@url}?q=string&p=3", []).body =~ ~r/test_response_before/
         HttpServer.stop(@port)
 
         # this method call should NOT be mocked as previous "test_response_before" response

--- a/test/handler_stub_mode_test.exs
+++ b/test/handler_stub_mode_test.exs
@@ -31,6 +31,14 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
     end
   end
 
+  test "url matches as regardless of query param order" do
+    use_cassette :stub, [url: "http://localhost?param1=10&param2=20&param3=30"] do
+      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost?param3=30&param1=10&param2=20', [], :get)
+      assert status_code == '200'
+      assert to_string(body) =~ ~r/Hello World/
+    end
+  end
+
   test "url matches as regex" do
     use_cassette :stub, [url: "~r/.+/"] do
       {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost', [], :get)


### PR DESCRIPTION
Before these changes, if the request body or URL contained a list of params that were in a different order than the params in the cassette, the request would fail to match the cassette.

As of OTP 26, map key order is not guaranteed, so request bodies and URL params that are created using maps can fail to match since the order of their keys is not idempotent.

These changes convert the request body and URL params to a sorted list before comparing it to the request body and URL in the cassette. This ensures cassettes will be matched as long as their request bodies and URL params contain the same set of key-value pairs as the incoming request.