### PR TITLE
Support for Multiple Stub Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,23 @@ test "stub request works for Finch" do
   assert Map.new(response.headers)["content-type"] == "text/html"
   assert response.status_code == 200
 end
+
+test "stub multiple requests works on Finch" do
+  stubs = [
+    [url: "http://example.com/1", body: "Stub Response 1", status_code: 200],
+    [url: "http://example.com/2", body: "Stub Response 2", status_code: 404]
+  ]
+
+  use_cassette :stub, stubs do
+    {:ok, response} = Finch.build(:get, "http://example.com/1") |> Finch.request(ExVCRFinch)
+    assert response.status == 200
+    assert response.body =~ ~r/Stub Response 1/
+
+    {:ok, response} = Finch.build(:get, "http://example.com/2") |> Finch.request(ExVCRFinch)
+    assert response.status == 404
+    assert response.body =~ ~r/Stub Response 2/
+  end
+end
 ```
 
 If the specified `:url` parameter doesn't match requests called inside the

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -142,7 +142,7 @@ defmodule ExVCR.Mock do
     if Keyword.keyword?(options) do
       prepare_stub_record(options, adapter)
     else
-      Enum.map(options, &prepare_stub_record(&1, adapter)) |> List.flatten()
+      Enum.flat_map(options, &prepare_stub_record(&1, adapter))
     end
   end
 

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -37,7 +37,7 @@ defmodule ExVCR.Mock do
   defmacro use_cassette(:stub, options, test) do
     quote do
       stub_fixture = "stub_fixture_#{ExVCR.Util.uniq_id}"
-      stub = prepare_stub_record(unquote(options), adapter_method())
+      stub = prepare_stub_records(unquote(options), adapter_method())
       recorder = Recorder.start([fixture: stub_fixture, stub: stub, adapter: adapter_method()])
 
       try do
@@ -133,6 +133,17 @@ defmodule ExVCR.Mock do
       end
     end)
     |> Task.await(:infinity)
+  end
+
+  @doc """
+  Prepare stub records
+  """
+  def prepare_stub_records(options, adapter) do
+    if Keyword.keyword?(options) do
+      prepare_stub_record(options, adapter)
+    else
+      Enum.map(options, &prepare_stub_record(&1, adapter)) |> List.flatten()
+    end
   end
 
   @doc """

--- a/test/adapter_finch_test.exs
+++ b/test/adapter_finch_test.exs
@@ -142,6 +142,23 @@ defmodule ExVCR.Adapter.FinchTest do
     end
   end
 
+  test "stub multiple requests works on Finch" do
+    stubs = [
+      [url: "http://example.com/1", body: "Stub Response 1", status_code: 200],
+      [url: "http://example.com/2", body: "Stub Response 2", status_code: 404]
+    ]
+
+    use_cassette :stub, stubs do
+      {:ok, response} = Finch.build(:get, "http://example.com/1") |> Finch.request(ExVCRFinch)
+      assert response.status == 200
+      assert response.body =~ ~r/Stub Response 1/
+
+      {:ok, response} = Finch.build(:get, "http://example.com/2") |> Finch.request(ExVCRFinch)
+      assert response.status == 404
+      assert response.body =~ ~r/Stub Response 2/
+    end
+  end
+
   test "single request using request!" do
     use_cassette "example_finch" do
       response = Finch.build(:get, "http://example.com") |> Finch.request!(ExVCRFinch)

--- a/test/adapter_ibrowse_test.exs
+++ b/test/adapter_ibrowse_test.exs
@@ -150,6 +150,23 @@ defmodule ExVCR.Adapter.IBrowseTest do
     end
   end
 
+  test "stub multiple requests works for ibrowse" do
+    stubs = [
+      [url: "http://example.com/1", body: "Stub Response 1", status_code: 200],
+      [url: "http://example.com/2", body: "Stub Response 2", status_code: 404]
+    ]
+
+    use_cassette :stub, stubs do
+      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://example.com/1', [], :get)
+      assert status_code == '200'
+      assert to_string(body) =~ ~r/Stub Response 1/
+
+      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://example.com/2', [], :get)
+      assert status_code == '404'
+      assert to_string(body) =~ ~r/Stub Response 2/
+    end
+  end
+
   defp assert_response(response, function \\ nil) do
     assert HTTPotion.Response.success?(response, :extra)
     assert response.headers[:Connection] == "keep-alive"


### PR DESCRIPTION
Hello there! 👋

Since we support multiple requests when using fixtures I thought it would be nice to support multiple requests also when using the `:stub` option.

This feature is quite useful in scenarios in which we need to create stubs manually or dynamically.

Usage:

```elixir
  stubs = [
    [url: "http://example.com/1", body: "Stub Response 1", status_code: 200],
    [url: "http://example.com/2", body: "Stub Response 2", status_code: 404]
  ]

  use_cassette :stub, stubs do
    {:ok, response} = Finch.build(:get, "http://example.com/1") |> Finch.request(ExVCRFinch)
    assert response.status == 200
    assert response.body =~ ~r/Stub Response 1/

    {:ok, response} = Finch.build(:get, "http://example.com/2") |> Finch.request(ExVCRFinch)
    assert response.status == 404
    assert response.body =~ ~r/Stub Response 2/
  end
```

Thank you for your time and for maintaining this awesome library!
Please let me know if any change is required.