### PR TITLE
fix: link rendering and code highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@
 [![License](https://img.shields.io/hexpm/l/exvcr.svg)](http://opensource.org/licenses/MIT)
 
 Record and replay HTTP interactions library for Elixir.  It's inspired by
-Ruby's VCR (https://github.com/vcr/vcr), and trying to provide similar
+[Ruby's VCR](https://github.com/vcr/vcr), and trying to provide similar
 functionalities.
 
 ### Basics
 
 The following HTTP libraries can be applied.
 
-  - <a href="https://github.com/cmullaparthi/ibrowse" target="_blank">ibrowse</a>-based libraries.
-    - <a href="https://github.com/myfreeweb/httpotion" target="_blank">HTTPotion</a>
-  - <a href="https://github.com/benoitc/hackney" target="_blank">hackney</a>-based libraries.
-    - <a href="https://github.com/edgurgel/httpoison" target="_blank">HTTPoison</a>
+  - [ibrowse](https://github.com/cmullaparthi/ibrowse){:target="_blank" rel="noopener"}-based libraries.
+    - [HTTPotion](https://github.com/myfreeweb/httpotion){:target="_blank" rel="noopener"}
+  - [hackney](https://github.com/benoitc/hackney){:target="_blank" rel="noopener"}-based libraries.
+    - [HTTPoison](https://github.com/edgurgel/httpoison){:target="_blank" rel="noopener"}
     - support is very limited, and tested only with sync request of HTTPoison yet.
-  - <a href="http://erlang.org/doc/man/httpc.html" target="_blank">httpc</a>-based libraries.
-    - <a href="https://github.com/tim/erlang-oauth/" target="_blank">erlang-oauth</a>
-    - <a href="https://github.com/Zatvobor/tirexs" target="_blank">tirexs</a>
+  - [httpc](http://erlang.org/doc/man/httpc.html){:target="_blank" rel="noopener"}-based libraries.
+    - [erlang-oauth](https://github.com/tim/erlang-oauth/){:target="_blank" rel="noopener"}
+    - [tirexs](https://github.com/Zatvobor/tirexs){:target="_blank" rel="noopener"}
     - support is very limited, and tested only with `:httpc.request/1` and `:httpc.request/4`.
-  - <a href="https://github.com/keathley/finch" target="_blank">Finch</a>
+  - [Finch](https://github.com/keathley/finch){:target="_blank" rel="noopener"}
     - the deprecated `Finch.request/6` functions is not supported
 
 HTTP interactions are recorded as JSON file. The JSON file can be recorded
@@ -64,7 +64,7 @@ using `hackney`, specify `adapter: ExVCR.Adapter.Hackney` options as follows.
 
 ##### Example with ibrowse
 
-```Elixir
+```elixir
 defmodule ExVCR.Adapter.IBrowseTest do
   use ExUnit.Case, async: true
   use ExVCR.Mock
@@ -94,7 +94,7 @@ end
 
 ##### Example with hackney
 
-```Elixir
+```elixir
 defmodule ExVCR.Adapter.HackneyTest do
   use ExUnit.Case, async: true
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
@@ -114,7 +114,7 @@ end
 
 ##### Example with httpc
 
-```Elixir
+```elixir
 defmodule ExVCR.Adapter.HttpcTest do
   use ExUnit.Case, async: true
   use ExVCR.Mock, adapter: ExVCR.Adapter.Httpc
@@ -136,7 +136,7 @@ end
 
 ##### Example with Finch
 
-```Elixir
+```elixir
 defmodule ExVCR.Adapter.FinchTest do
   use ExUnit.Case, async: true
   use ExVCR.Mock, adapter: ExVCR.Adapter.Finch
@@ -161,13 +161,13 @@ end
 
 Instead of single `use_cassette`, `start_cassette` and `stop_cassette` can serve as an alternative syntax.
 
-```Elixir
+```elixir
 use_cassette("x") do
   do_something
 end
 ```
 
-```Elixir
+```elixir
 start_cassette("x")
 do_something
 stop_cassette
@@ -187,7 +187,7 @@ control rather than just recoding the actual server response.
   of requesting to server.
 
 
-```Elixir
+```elixir
 defmodule ExVCR.MockTest do
   use ExUnit.Case, async: true
   import ExVCR.Mock
@@ -667,7 +667,7 @@ iex(2)> ExVCR.IEx.print(adapter: ExVCR.Adapter.Hackney) do
 Specifying `:stub` as fixture name allows directly stubbing the response
 header/body information based on parameter.
 
-```Elixir
+```elixir
 test "stub request works for HTTPotion" do
   use_cassette :stub, [url: "http://example.com", body: "Stub Response", status_code: 200] do
     response = HTTPotion.get("http://example.com", [])
@@ -733,7 +733,7 @@ If the specified `:url` parameter doesn't match requests called inside the
 The `:url` can be regular expression string. Please note that you should use
 the `~r` sigil with `/` as delimiters.
 
-```Elixir
+```elixir
 test "match URL with regular expression" do
   use_cassette :stub, [url: "~r/(foo|bar)/", body: "Stub Response", status_code: 200] do
     # ...


### PR DESCRIPTION
Hi thanks a lot for your work on exvcr! I was recently playing a bit with it and found some issues on the documentation, so I thought a PR would help you.

The readme has some links that are not rendering well on https://hexdocs.pm/exvcr, in addition some of the code examples use `Elixir` as language name, so the highlighting doesn't work.

I've changed the links so that they render well on hexdocs and rexpect the existing `target="_blank"`.

I've also changed the language in the codeblocks so that it is correctly highlighted on both hexdocs and GitHub.

## Note

I was only able to get the docs rendered on Elixir 1.14. I tried 1.15 and 1.16 too, but they didn't work and I was always getting an error like this:

```
❯ mix docs               
Generated exvcr app

13:46:12.122 [notice] Application makeup exited: exited in: Makeup.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Makeup.Application.start/2 is undefined (module Makeup.Application is not available)
            (makeup 1.1.2) Makeup.Application.start(:normal, [])
            (kernel 9.2.4) application_master.erl:293: :application_master.start_it_old/4

13:46:12.127 [notice] Application nimble_parsec exited: :stopped

13:46:12.127 [notice] Application earmark_parser exited: :stopped

13:46:12.127 [notice] Application eex exited: :stopped
** (MatchError) no match of right hand side value: {:error, {:makeup, {:bad_return, {{Makeup.Application, :start, [:normal, []]}, {:EXIT, {:undef, [{Makeup.Application, :start, [:normal, []], []}, {:applic
ation_master, :start_it_old, 4, [file: ~c"application_master.erl", line: 293]}]}}}}}}
    (ex_doc 0.34.0) lib/mix/tasks/docs.ex:336: Mix.Tasks.Docs.run/3
    (mix 1.15.8) lib/mix/task.ex:455: anonymous fn/3 in Mix.Task.run_task/5
    (mix 1.15.8) lib/mix/cli.ex:92: Mix.CLI.run_task/2
    /path_to/elixir/shims/mix:4: (file)

```

I imagined this might be an error on some of the rendering libraries used by `ex_docs` but I didn't want to have to upgrade them all.

## Links
### Before
<img width="918" alt="Screenshot 2024-06-09 at 14 13 15" src="https://github.com/parroty/exvcr/assets/186087/4d6f9c4e-1a8f-45e4-9de8-0462801b1793">

### After
<img width="843" alt="Screenshot 2024-06-09 at 14 14 16" src="https://github.com/parroty/exvcr/assets/186087/40d8cd52-c78a-4628-a789-cc6fd5d09f3e">

## Code blocks

### Before
<img width="1003" alt="Screenshot 2024-06-09 at 14 14 47" src="https://github.com/parroty/exvcr/assets/186087/5537ad86-3dc9-4241-827d-c37e28ed5ef8">


### After

<img width="928" alt="Screenshot 2024-06-09 at 14 14 55" src="https://github.com/parroty/exvcr/assets/186087/93a08cf8-91a5-4b90-a64b-ca3be910a878">
