### PR TITLE
Fix versions in actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,16 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        otp: ['21','23']
+        otp: ['23']
         elixir: ['1.10', '1.11']
         global-mock: [true, false]
         include:
+          - otp: '24'
+            elixir: '1.12'
+            global-mock: true
+          - otp: '24'
+            elixir: '1.12'
+            global-mock: false
           - otp: '26'
             elixir: '1.14'
             global-mock: true
@@ -23,12 +29,12 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GLOBAL_MOCK: ${{ matrix.global-mock }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
          otp-version: ${{ matrix.otp }}
          elixir-version: ${{ matrix.elixir }}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             deps
@@ -37,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
       - run: mix deps.get
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v3
         with:
           timeout_minutes: 3
           max_attempts: 3


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/tests.yml` file to update the test environment and the actions used in the GitHub workflow. The most important changes are updating the OTP and Elixir versions used in the test matrix, updating the versions of the GitHub actions used, and replacing the `retry` action with a newer version.

Test environment updates:
* OTP version '21' was removed from the test matrix, and versions '24' with Elixir '1.12' were added. This change updates the versions of OTP and Elixir that the tests are run against, ensuring compatibility with newer versions of these tools.

GitHub actions updates:
* The `actions/checkout` and `actions/cache` actions were updated to version 4. These updates may include bug fixes, new features, or performance improvements.
* The `nick-invision/retry` action was updated to version 3, which may include improvements over the previous version.