### PR TITLE
Update Elixir versions under test with GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,11 +28,11 @@ jobs:
             global-mock: false
             experimental: false
           - otp: "27.2"
-            elixir: "1.18.0-rc.0"
+            elixir: "1.18.0"
             global-mock: true
             experimental: true
           - otp: "27.2"
-            elixir: "1.18.0-rc.0"
+            elixir: "1.18.0"
             global-mock: false
             experimental: true
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,25 +5,36 @@ on: [push, pull_request]
 jobs:
   tests:
     name: Run Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: true
       matrix:
-        otp: ['23']
-        elixir: ['1.10', '1.11']
-        global-mock: [true, false]
         include:
-          - otp: '24'
-            elixir: '1.12'
-            global-mock: true
-          - otp: '24'
-            elixir: '1.12'
-            global-mock: false
           - otp: '26'
-            elixir: '1.14'
+            elixir: '1.16'
             global-mock: true
+            experimental: false
           - otp: '26'
-            elixir: '1.14'
+            elixir: '1.16'
             global-mock: false
+            experimental: false
+          - otp: "27"
+            elixir: "1.17"
+            global-mock: true
+            experimental: false
+          - otp: "27"
+            elixir: "1.17"
+            global-mock: false
+            experimental: false
+          - otp: "27.2"
+            elixir: "1.18.0-rc.0"
+            global-mock: true
+            experimental: true
+          - otp: "27.2"
+            elixir: "1.18.0-rc.0"
+            global-mock: false
+            experimental: true
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#223
#224

With Elixir 1.18 release candidate marked as experimental -- it won't fail the build if it fails.