### PR TITLE
Update GitHub Actions workflow to use Ubuntu 22.04 and add support for Elixir 1.16 and 1.18.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,12 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - otp: '26'
-            elixir: '1.16'
+          - otp: '25'
+            elixir: '1.14'
             global-mock: true
             experimental: false
-          - otp: '26'
-            elixir: '1.16'
+          - otp: '25'
+            elixir: '1.14'
             global-mock: false
             experimental: false
           - otp: "27"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,25 +5,36 @@ on: [push, pull_request]
 jobs:
   tests:
     name: Run Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: true
       matrix:
-        otp: ['23']
-        elixir: ['1.10', '1.11']
-        global-mock: [true, false]
         include:
-          - otp: '24'
-            elixir: '1.12'
-            global-mock: true
-          - otp: '24'
-            elixir: '1.12'
-            global-mock: false
           - otp: '26'
-            elixir: '1.14'
+            elixir: '1.16'
             global-mock: true
+            experimental: false
           - otp: '26'
-            elixir: '1.14'
+            elixir: '1.16'
             global-mock: false
+            experimental: false
+          - otp: "27"
+            elixir: "1.17"
+            global-mock: true
+            experimental: false
+          - otp: "27"
+            elixir: "1.17"
+            global-mock: false
+            experimental: false
+          - otp: "27.2"
+            elixir: "1.18.0"
+            global-mock: true
+            experimental: true
+          - otp: "27.2"
+            elixir: "1.18.0"
+            global-mock: false
+            experimental: true
     env:
       MIX_ENV: test
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,9 +54,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-
       - run: mix deps.get
+      - run: mix test
       - uses: nick-invision/retry@v3
         with:
           timeout_minutes: 3
           max_attempts: 3
           shell: bash
           command: mix coveralls.github
+        continue-on-error: true

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,6 @@ defmodule ExVCR.Mixfile do
 
   def application do
     [
-      applications: [:meck, :exactor, :exjsx],
       extra_applications: extra_applications(Mix.env()),
       mod: {ExVCR.Application, []}
     ]
@@ -32,7 +31,7 @@ defmodule ExVCR.Mixfile do
   defp extra_applications(_), do: []
 
   defp common_extra_applications do
-    [:inets, :ranch, :telemetry, :finch, :ibrowse, :hackney, :http_server, :httpotion, :httpoison]
+    [:inets, :ranch, :telemetry, :finch, :ibrowse, :hackney, :http_server, :httpotion, :httpoison, :excoveralls]
   end
 
   def deps do


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration to enhance the testing matrix and improve error handling. The key changes are:

Workflow configuration updates:

* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL8-R37): Updated the `runs-on` environment to `ubuntu-22.04` and added the `continue-on-error` parameter to handle experimental configurations.
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL8-R37): Introduced the `fail-fast` parameter to the strategy to stop all jobs if any job fails.
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL8-R37): Expanded the testing matrix to include newer versions of OTP and Elixir, specifically OTP 27 and Elixir 1.17 and 1.18.0.