### PR TITLE
Fix charlist warnings in tests

### DIFF
--- a/test/adapter_finch_test.exs
+++ b/test/adapter_finch_test.exs
@@ -244,6 +244,6 @@ defmodule ExVCR.Adapter.FinchTest do
     assert response.status in 200..299
     assert Map.new(response.headers)["connection"] == "keep-alive"
     assert is_binary(response.body)
-    unless function == nil, do: function.(response)
+    if function != nil, do: function.(response)
   end
 end

--- a/test/adapter_hackney_test.exs
+++ b/test/adapter_hackney_test.exs
@@ -241,6 +241,6 @@ defmodule ExVCR.Adapter.HackneyTest do
   defp assert_response(response, function \\ nil) do
     assert response.status_code == 200
     assert is_binary(response.body)
-    unless function == nil, do: function.(response)
+    if function != nil, do: function.(response)
   end
 end

--- a/test/adapter_httpc_test.exs
+++ b/test/adapter_httpc_test.exs
@@ -43,18 +43,20 @@ defmodule ExVCR.Adapter.HttpcTest do
 
   test "example httpc request/1" do
     use_cassette "example_httpc_request_1" do
-      {:ok, result} = :httpc.request('http://example.com')
+      {:ok, result} = :httpc.request(~c"http://example.com")
       {{http_version, _status_code = 200, reason_phrase}, headers, body} = result
       assert to_string(body) =~ ~r/Example Domain/
-      assert http_version == 'HTTP/1.1'
-      assert reason_phrase == 'OK'
-      assert List.keyfind(headers, 'content-type', 0) == {'content-type', 'text/html'}
+      assert http_version == ~c"HTTP/1.1"
+      assert reason_phrase == ~c"OK"
+      assert List.keyfind(headers, ~c"content-type", 0) == {~c"content-type", ~c"text/html"}
     end
   end
 
   test "example httpc request/4" do
     use_cassette "example_httpc_request_4" do
-      {:ok, {{_, 200, _reason_phrase}, _headers, body}} = :httpc.request(:get, {'http://example.com', ''}, '', '')
+      {:ok, {{_, 200, _reason_phrase}, _headers, body}} =
+        :httpc.request(:get, {~c"http://example.com", ~c""}, ~c"", ~c"")
+
       assert to_string(body) =~ ~r/Example Domain/
     end
   end
@@ -64,7 +66,7 @@ defmodule ExVCR.Adapter.HttpcTest do
       {:ok, {{_, 200, _reason_phrase}, _headers, body}} =
         :httpc.request(
           :get,
-          {'http://example.com', [{'Content-Type', 'text/html'}]},
+          {~c"http://example.com", [{~c"Content-Type", ~c"text/html"}]},
           [connect_timeout: 3000, timeout: 5000],
           body_format: :binary
         )
@@ -75,17 +77,17 @@ defmodule ExVCR.Adapter.HttpcTest do
 
   test "example httpc request error" do
     use_cassette "example_httpc_request_error" do
-      {:error, {reason, _detail}} = :httpc.request('http://invalidurl')
+      {:error, {reason, _detail}} = :httpc.request(~c"http://invalidurl")
       assert reason == :failed_connect
     end
   end
 
   test "stub request works" do
-    use_cassette :stub, url: 'http://example.com', body: 'Stub Response' do
-      {:ok, result} = :httpc.request('http://example.com')
+    use_cassette :stub, url: ~c"http://example.com", body: ~c"Stub Response" do
+      {:ok, result} = :httpc.request(~c"http://example.com")
       {{_http_version, _status_code = 200, _reason_phrase}, headers, body} = result
       assert to_string(body) =~ ~r/Stub Response/
-      assert List.keyfind(headers, 'content-type', 0) == {'content-type', 'text/html'}
+      assert List.keyfind(headers, ~c"content-type", 0) == {~c"content-type", ~c"text/html"}
     end
   end
 end

--- a/test/adapter_ibrowse_test.exs
+++ b/test/adapter_ibrowse_test.exs
@@ -23,7 +23,7 @@ defmodule ExVCR.Adapter.IBrowseTest do
 
     url = "http://localhost:#{@port}/server" |> to_charlist()
     {:ok, status_code, _headers, _body} = :ibrowse.send_req(url, [], :get)
-    assert status_code == '200'
+    assert status_code == ~c"200"
   end
 
   test "passthrough works after cassette has been used" do
@@ -31,37 +31,37 @@ defmodule ExVCR.Adapter.IBrowseTest do
 
     use_cassette "ibrowse_get_localhost" do
       {:ok, status_code, _headers, _body} = :ibrowse.send_req(url, [], :get)
-      assert status_code == '200'
+      assert status_code == ~c"200"
     end
 
     {:ok, status_code, _headers, _body} = :ibrowse.send_req(url, [], :get)
-    assert status_code == '200'
+    assert status_code == ~c"200"
   end
 
   test "example single request" do
     use_cassette "example_ibrowse" do
-      {:ok, status_code, headers, body} = :ibrowse.send_req('http://example.com', [], :get)
-      assert status_code == '200'
-      assert List.keyfind(headers, 'Content-Type', 0) == {'Content-Type', 'text/html'}
+      {:ok, status_code, headers, body} = :ibrowse.send_req(~c"http://example.com", [], :get)
+      assert status_code == ~c"200"
+      assert List.keyfind(headers, ~c"Content-Type", 0) == {~c"Content-Type", ~c"text/html"}
       assert to_string(body) =~ ~r/Example Domain/
     end
   end
 
   test "example multiple requests" do
     use_cassette "example_ibrowse_multiple" do
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://example.com', [], :get)
-      assert status_code == '200'
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://example.com", [], :get)
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Example Domain/
 
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://example.com/2', [], :get)
-      assert status_code == '404'
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://example.com/2", [], :get)
+      assert status_code == ~c"404"
       assert to_string(body) =~ ~r/Example Domain/
     end
   end
 
   test "single request with error" do
     use_cassette "error_ibrowse" do
-      response = :ibrowse.send_req('http://invalid_url', [], :get)
+      response = :ibrowse.send_req(~c"http://invalid_url", [], :get)
       assert response == {:error, {:conn_failed, {:error, :nxdomain}}}
     end
   end
@@ -125,22 +125,22 @@ defmodule ExVCR.Adapter.IBrowseTest do
 
   test "using recorded cassette, but requesting with different url should return error" do
     use_cassette "example_ibrowse_different" do
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://example.com', [], :get)
-      assert status_code == '200'
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://example.com", [], :get)
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Example Domain/
     end
 
     use_cassette "example_ibrowse_different" do
       assert_raise ExVCR.RequestNotMatchError, ~r/different_from_original/, fn ->
-        :ibrowse.send_req('http://example.com/different_from_original', [], :get)
+        :ibrowse.send_req(~c"http://example.com/different_from_original", [], :get)
       end
     end
   end
 
   test "stub request works for ibrowse" do
-    use_cassette :stub, url: 'http://example.com', body: 'Stub Response', status_code: 200 do
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://example.com', [], :get)
-      assert status_code == '200'
+    use_cassette :stub, url: ~c"http://example.com", body: ~c"Stub Response", status_code: 200 do
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://example.com", [], :get)
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Stub Response/
     end
   end
@@ -161,12 +161,12 @@ defmodule ExVCR.Adapter.IBrowseTest do
     ]
 
     use_cassette :stub, stubs do
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://example.com/1', [], :get)
-      assert status_code == '200'
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://example.com/1", [], :get)
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Stub Response 1/
 
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://example.com/2', [], :get)
-      assert status_code == '404'
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://example.com/2", [], :get)
+      assert status_code == ~c"404"
       assert to_string(body) =~ ~r/Stub Response 2/
     end
   end
@@ -175,6 +175,6 @@ defmodule ExVCR.Adapter.IBrowseTest do
     assert HTTPotion.Response.success?(response, :extra)
     assert response.headers[:Connection] == "keep-alive"
     assert is_binary(response.body)
-    unless function == nil, do: function.(response)
+    if function != nil, do: function.(response)
   end
 end

--- a/test/handler_stub_mode_test.exs
+++ b/test/handler_stub_mode_test.exs
@@ -9,83 +9,85 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
 
   test "empty options works with default parameters" do
     use_cassette :stub, [] do
-      {:ok, status_code, headers, body} = :ibrowse.send_req('http://localhost', [], :get)
-      assert status_code == '200'
-      assert List.keyfind(headers, 'Content-Type', 0) == {'Content-Type', 'text/html'}
+      {:ok, status_code, headers, body} = :ibrowse.send_req(~c"http://localhost", [], :get)
+      assert status_code == ~c"200"
+      assert List.keyfind(headers, ~c"Content-Type", 0) == {~c"Content-Type", ~c"text/html"}
       assert to_string(body) =~ ~r/Hello World/
     end
   end
 
   test "specified options should match with return values" do
-    use_cassette :stub, url: 'http://localhost', body: 'NotFound', status_code: 404 do
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost', [], :get)
-      assert status_code == '404'
+    use_cassette :stub, url: ~c"http://localhost", body: ~c"NotFound", status_code: 404 do
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://localhost", [], :get)
+      assert status_code == ~c"404"
       assert to_string(body) =~ ~r/NotFound/
     end
   end
 
   test "method name in atom works" do
-    use_cassette :stub, url: 'http://localhost', method: :post, request_body: 'param1=value1&param2=value2' do
+    use_cassette :stub, url: ~c"http://localhost", method: :post, request_body: ~c"param1=value1&param2=value2" do
       {:ok, status_code, _headers, _body} =
-        :ibrowse.send_req('http://localhost', [], :post, 'param1=value1&param2=value2')
+        :ibrowse.send_req(~c"http://localhost", [], :post, ~c"param1=value1&param2=value2")
 
-      assert status_code == '200'
+      assert status_code == ~c"200"
     end
   end
 
   test "url matches as regardless of query param order" do
     use_cassette :stub, url: "http://localhost?param1=10&param2=20&param3=30" do
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost?param3=30&param1=10&param2=20', [], :get)
-      assert status_code == '200'
+      {:ok, status_code, _headers, body} =
+        :ibrowse.send_req(~c"http://localhost?param3=30&param1=10&param2=20", [], :get)
+
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Hello World/
     end
   end
 
   test "url matches as regex" do
     use_cassette :stub, url: "~r/.+/" do
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost', [], :get)
-      assert status_code == '200'
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://localhost", [], :get)
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Hello World/
     end
   end
 
   test "request_body matches as string" do
-    use_cassette :stub, url: 'http://localhost', method: :post, request_body: "some-string", body: "Hello World" do
-      {:ok, status_code, _headers, body} = :ibrowse.send_req('http://localhost', [], :post, 'some-string')
-      assert status_code == '200'
+    use_cassette :stub, url: ~c"http://localhost", method: :post, request_body: "some-string", body: "Hello World" do
+      {:ok, status_code, _headers, body} = :ibrowse.send_req(~c"http://localhost", [], :post, ~c"some-string")
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Hello World/
     end
   end
 
   test "request_body matches as regex" do
-    use_cassette :stub, url: 'http://localhost', method: :post, request_body: "~r/param1/", body: "Hello World" do
+    use_cassette :stub, url: ~c"http://localhost", method: :post, request_body: "~r/param1/", body: "Hello World" do
       {:ok, status_code, _headers, body} =
-        :ibrowse.send_req('http://localhost', [], :post, 'param1=value1&param2=value2')
+        :ibrowse.send_req(~c"http://localhost", [], :post, ~c"param1=value1&param2=value2")
 
-      assert status_code == '200'
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Hello World/
     end
   end
 
   test "request_body mismatches as regex" do
     assert_raise ExVCR.InvalidRequestError, fn ->
-      use_cassette :stub, url: 'http://localhost', method: :post, request_body: "~r/param3/", body: "Hello World" do
+      use_cassette :stub, url: ~c"http://localhost", method: :post, request_body: "~r/param3/", body: "Hello World" do
         {:ok, _status_code, _headers, _body} =
-          :ibrowse.send_req('http://localhost', [], :post, 'param1=value1&param2=value2')
+          :ibrowse.send_req(~c"http://localhost", [], :post, ~c"param1=value1&param2=value2")
       end
     end
   end
 
   test "request_body matches as unordered list of params" do
     use_cassette :stub,
-      url: 'http://localhost',
+      url: ~c"http://localhost",
       method: :post,
       request_body: "param1=10&param3=30&param2=20",
       body: "Hello World" do
       {:ok, status_code, _headers, body} =
-        :ibrowse.send_req('http://localhost', [], :post, 'param2=20&param1=10&param3=30')
+        :ibrowse.send_req(~c"http://localhost", [], :post, ~c"param2=20&param1=10&param3=30")
 
-      assert status_code == '200'
+      assert status_code == ~c"200"
       assert to_string(body) =~ ~r/Hello World/
     end
   end
@@ -93,43 +95,45 @@ defmodule ExVCR.Adapter.HandlerStubModeTest do
   test "request_body mismatches as unordered list of params" do
     assert_raise ExVCR.InvalidRequestError, fn ->
       use_cassette :stub,
-        url: 'http://localhost',
+        url: ~c"http://localhost",
         method: :post,
         request_body: "param1=10&param3=30&param4=40",
         body: "Hello World" do
         {:ok, _status_code, _headers, _body} =
-          :ibrowse.send_req('http://localhost', [], :post, 'param2=20&param1=10&param3=30')
+          :ibrowse.send_req(~c"http://localhost", [], :post, ~c"param2=20&param1=10&param3=30")
       end
     end
   end
 
   test "request_body mismatch should raise error" do
     assert_raise ExVCR.InvalidRequestError, fn ->
-      use_cassette :stub, url: 'http://localhost', method: :post, request_body: '{"one" => 1}' do
-        {:ok, _status_code, _headers, _body} = :ibrowse.send_req('http://localhost', [], :post)
+      use_cassette :stub, url: ~c"http://localhost", method: :post, request_body: ~c'{"one" => 1}' do
+        {:ok, _status_code, _headers, _body} = :ibrowse.send_req(~c"http://localhost", [], :post)
       end
     end
   end
 
   test "post request without request_body definition should ignore request body" do
-    use_cassette :stub, url: 'http://localhost', method: :post, status_code: 500 do
-      {:ok, status_code, _headers, _body} = :ibrowse.send_req('http://localhost', [], :post, 'param=should_be_ignored')
-      assert status_code == '500'
+    use_cassette :stub, url: ~c"http://localhost", method: :post, status_code: 500 do
+      {:ok, status_code, _headers, _body} =
+        :ibrowse.send_req(~c"http://localhost", [], :post, ~c"param=should_be_ignored")
+
+      assert status_code == ~c"500"
     end
   end
 
   test "url mismatch should raise error" do
     assert_raise ExVCR.InvalidRequestError, fn ->
-      use_cassette :stub, url: 'http://localhost' do
-        {:ok, _status_code, _headers, _body} = :ibrowse.send_req('http://www.example.com', [], :get)
+      use_cassette :stub, url: ~c"http://localhost" do
+        {:ok, _status_code, _headers, _body} = :ibrowse.send_req(~c"http://www.example.com", [], :get)
       end
     end
   end
 
   test "method mismatch should raise error" do
     assert_raise ExVCR.InvalidRequestError, fn ->
-      use_cassette :stub, url: 'http://localhost', method: "post" do
-        {:ok, _status_code, _headers, _body} = :ibrowse.send_req('http://localhost', [], :get)
+      use_cassette :stub, url: ~c"http://localhost", method: "post" do
+        {:ok, _status_code, _headers, _body} = :ibrowse.send_req(~c"http://localhost", [], :get)
       end
     end
   end

--- a/test/iex_test.exs
+++ b/test/iex_test.exs
@@ -19,7 +19,7 @@ defmodule ExVCR.IExTest do
   test "print request/response" do
     assert capture_io(fn ->
              ExVCR.IEx.print do
-               :ibrowse.send_req('http://localhost:34005/server', [], :get)
+               :ibrowse.send_req(~c"http://localhost:34005/server", [], :get)
              end
            end) =~ ~r/\"body\": \"test_response\"/
   end

--- a/test/recorder_httpc_test.exs
+++ b/test/recorder_httpc_test.exs
@@ -4,8 +4,8 @@ defmodule ExVCR.RecorderHttpcTest do
 
   @dummy_cassette_dir "tmp/vcr_tmp/vcr_cassettes_httpc"
   @port 34001
-  @url 'http://localhost:#{@port}/server'
-  @url_with_query 'http://localhost:#{@port}/server?password=sample'
+  @url ~c"http://localhost:#{@port}/server"
+  @url_with_query ~c"http://localhost:#{@port}/server?password=sample"
 
   setup_all do
     on_exit(fn ->
@@ -73,7 +73,9 @@ defmodule ExVCR.RecorderHttpcTest do
     ExVCR.Config.filter_request_headers("X-My-Secret-Token")
 
     use_cassette "sensitive_data_in_request_header" do
-      {:ok, {_, _, body}} = :httpc.request(:get, {@url_with_query, [{'X-My-Secret-Token', 'my-secret-token'}]}, [], [])
+      {:ok, {_, _, body}} =
+        :httpc.request(:get, {@url_with_query, [{~c"X-My-Secret-Token", ~c"my-secret-token"}]}, [], [])
+
       assert body == "test_response"
     end
 
@@ -89,7 +91,9 @@ defmodule ExVCR.RecorderHttpcTest do
     ExVCR.Config.filter_sensitive_data("Basic [a-z]+", "Basic ***")
 
     use_cassette "sensitive_data_matches_in_request_headers", match_requests_on: [:headers] do
-      {:ok, {_, _, body}} = :httpc.request(:get, {@url_with_query, [{'Authorization', 'Basic credentials'}]}, [], [])
+      {:ok, {_, _, body}} =
+        :httpc.request(:get, {@url_with_query, [{~c"Authorization", ~c"Basic credentials"}]}, [], [])
+
       assert body =~ ~r/test_response/
     end
 
@@ -99,7 +103,9 @@ defmodule ExVCR.RecorderHttpcTest do
 
     # Attempt another request should match on filtered header
     use_cassette "sensitive_data_matches_in_request_headers", match_requests_on: [:headers] do
-      {:ok, {_, _, body}} = :httpc.request(:get, {@url_with_query, [{'Authorization', 'Basic credentials'}]}, [], [])
+      {:ok, {_, _, body}} =
+        :httpc.request(:get, {@url_with_query, [{~c"Authorization", ~c"Basic credentials"}]}, [], [])
+
       assert body =~ ~r/test_response/
     end
 
@@ -110,7 +116,7 @@ defmodule ExVCR.RecorderHttpcTest do
     ExVCR.Config.filter_url_params(true)
 
     use_cassette "example_ignore_url_params" do
-      {:ok, {_, _, body}} = :httpc.request('#{@url}?should_not_be_contained')
+      {:ok, {_, _, body}} = :httpc.request(~c"#{@url}?should_not_be_contained")
       assert body =~ ~r/test_response/
     end
 
@@ -124,7 +130,7 @@ defmodule ExVCR.RecorderHttpcTest do
 
     use_cassette "remove_blacklisted_headers" do
       {:ok, {_, headers, _}} = :httpc.request(@url)
-      assert Enum.sort(headers) == Enum.sort([{'server', 'Cowboy'}, {'content-length', '13'}])
+      assert Enum.sort(headers) == Enum.sort([{~c"server", ~c"Cowboy"}, {~c"content-length", ~c"13"}])
     end
 
     ExVCR.Config.response_headers_blacklist([])


### PR DESCRIPTION
Elixir 1.18 has introduced new `mix format --migrate` which allows to fix multiple warnings/deprecations at once.

This should simplify running tests for the library, given that running tests will no longer produce multiple screens of warnings.